### PR TITLE
Provide support for Hyperbolic CSC, SEC, COT in LaTeX parser

### DIFF
--- a/sympy/parsing/latex/LaTeX.g4
+++ b/sympy/parsing/latex/LaTeX.g4
@@ -59,9 +59,16 @@ FUNC_ARCCOT: '\\arccot';
 FUNC_SINH: '\\sinh';
 FUNC_COSH: '\\cosh';
 FUNC_TANH: '\\tanh';
+FUNC_CSCH: '\\csch';
+FUNC_SECH: '\\sech';
+FUNC_COTH: '\\coth';
+
 FUNC_ARSINH: '\\arsinh';
 FUNC_ARCOSH: '\\arcosh';
 FUNC_ARTANH: '\\artanh';
+FUNC_ARCSCH: '\\arcsch';
+FUNC_ARSECH: '\\arsech';
+FUNC_ARCOTH: '\\arcoth';
 
 FUNC_SQRT: '\\sqrt';
 
@@ -203,7 +210,9 @@ func_normal:
     | FUNC_ARCSIN | FUNC_ARCCOS | FUNC_ARCTAN
     | FUNC_ARCCSC | FUNC_ARCSEC | FUNC_ARCCOT
     | FUNC_SINH | FUNC_COSH | FUNC_TANH
-    | FUNC_ARSINH | FUNC_ARCOSH | FUNC_ARTANH;
+    | FUNC_CSCH | FUNC_SECH | FUNC_COTH
+    | FUNC_ARSINH | FUNC_ARCOSH | FUNC_ARTANH
+    | FUNC_ARCSCH | FUNC_ARSECH | FUNC_ARCOTH;
 
 func:
     func_normal

--- a/sympy/parsing/latex/_antlr/latexlexer.py
+++ b/sympy/parsing/latex/_antlr/latexlexer.py
@@ -16,10 +16,11 @@ from io import StringIO
 import sys
 
 
+
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2")
-        buf.write(u">\u0205\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4")
+        buf.write(u"D\u023b\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4")
         buf.write(u"\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r")
         buf.write(u"\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22")
         buf.write(u"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4")
@@ -28,217 +29,239 @@ def serializedATN():
         buf.write(u"$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4,\t")
         buf.write(u",\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63")
         buf.write(u"\t\63\4\64\t\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\4")
-        buf.write(u"9\t9\4:\t:\4;\t;\4<\t<\4=\t=\4>\t>\4?\t?\3\2\3\2\3\3")
-        buf.write(u"\6\3\u0083\n\3\r\3\16\3\u0084\3\3\3\3\3\4\3\4\3\5\3\5")
-        buf.write(u"\3\6\3\6\3\7\3\7\3\b\3\b\3\t\3\t\3\n\3\n\3\13\3\13\3")
-        buf.write(u"\f\3\f\3\r\3\r\3\16\3\16\3\17\3\17\3\17\3\17\3\17\3\20")
+        buf.write(u"9\t9\4:\t:\4;\t;\4<\t<\4=\t=\4>\t>\4?\t?\4@\t@\4A\tA")
+        buf.write(u"\4B\tB\4C\tC\4D\tD\4E\tE\3\2\3\2\3\3\6\3\u008f\n\3\r")
+        buf.write(u"\3\16\3\u0090\3\3\3\3\3\4\3\4\3\5\3\5\3\6\3\6\3\7\3\7")
+        buf.write(u"\3\b\3\b\3\t\3\t\3\n\3\n\3\13\3\13\3\f\3\f\3\r\3\r\3")
+        buf.write(u"\16\3\16\3\17\3\17\3\17\3\17\3\17\3\20\3\20\3\20\3\20")
         buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
         buf.write(u"\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20")
         buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
         buf.write(u"\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20")
-        buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
-        buf.write(u"\20\3\20\5\20\u00db\n\20\3\21\3\21\3\21\3\21\3\21\3\22")
-        buf.write(u"\3\22\3\22\3\22\3\22\3\23\3\23\3\23\3\23\3\23\3\23\3")
-        buf.write(u"\24\3\24\3\24\3\24\3\24\3\25\3\25\3\25\3\25\3\26\3\26")
-        buf.write(u"\3\26\3\26\3\26\3\27\3\27\3\27\3\27\3\27\3\30\3\30\3")
-        buf.write(u"\30\3\30\3\30\3\31\3\31\3\31\3\31\3\31\3\32\3\32\3\32")
-        buf.write(u"\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\34\3\34\3\34\3")
-        buf.write(u"\34\3\34\3\34\3\34\3\34\3\35\3\35\3\35\3\35\3\35\3\35")
-        buf.write(u"\3\35\3\35\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3")
-        buf.write(u"\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3 \3 \3 \3 \3")
-        buf.write(u" \3 \3 \3 \3!\3!\3!\3!\3!\3!\3!\3!\3\"\3\"\3\"\3\"\3")
-        buf.write(u"\"\3\"\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\3$\3%\3%\3%\3")
-        buf.write(u"%\3%\3%\3%\3%\3&\3&\3&\3&\3&\3&\3&\3&\3\'\3\'\3\'\3\'")
-        buf.write(u"\3\'\3\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3)")
-        buf.write(u"\3)\3*\3*\3*\3*\3*\3*\3+\3+\3+\3+\3+\3,\3,\3,\3,\3,\3")
-        buf.write(u",\3-\3-\3-\3-\3-\3-\3-\3.\3.\3.\3.\3.\3.\3.\3.\3/\3/")
-        buf.write(u"\3/\3/\3/\3/\3/\3/\3\60\3\60\3\60\3\60\3\60\3\60\3\60")
-        buf.write(u"\3\60\3\61\3\61\3\62\3\62\3\63\3\63\3\64\3\64\3\65\3")
-        buf.write(u"\65\7\65\u01b5\n\65\f\65\16\65\u01b8\13\65\3\65\3\65")
-        buf.write(u"\3\65\6\65\u01bd\n\65\r\65\16\65\u01be\5\65\u01c1\n\65")
-        buf.write(u"\3\66\3\66\3\67\3\67\38\68\u01c8\n8\r8\168\u01c9\38\3")
-        buf.write(u"8\38\38\38\78\u01d1\n8\f8\168\u01d4\138\38\78\u01d7\n")
-        buf.write(u"8\f8\168\u01da\138\38\38\38\38\38\78\u01e1\n8\f8\168")
-        buf.write(u"\u01e4\138\38\38\68\u01e8\n8\r8\168\u01e9\58\u01ec\n")
-        buf.write(u"8\39\39\3:\3:\3;\3;\3;\3;\3;\3<\3<\3=\3=\3=\3=\3=\3>")
-        buf.write(u"\3>\3?\3?\6?\u0202\n?\r?\16?\u0203\3\u01b6\2@\3\3\5\4")
-        buf.write(u"\7\5\t\6\13\7\r\b\17\t\21\n\23\13\25\f\27\r\31\16\33")
-        buf.write(u"\17\35\20\37\21!\22#\23%\24\'\25)\26+\27-\30/\31\61\32")
-        buf.write(u"\63\33\65\34\67\359\36;\37= ?!A\"C#E$G%I&K\'M(O)Q*S+")
-        buf.write(u"U,W-Y.[/]\60_\61a\62c\63e\64g\2i\65k\66m\2o\67q8s9u:")
-        buf.write(u"w;y<{=}>\3\2\5\5\2\13\f\17\17\"\"\4\2C\\c|\3\2\62;\2")
-        buf.write(u"\u0211\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2")
-        buf.write(u"\2\2\13\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3\2\2\2")
-        buf.write(u"\2\23\3\2\2\2\2\25\3\2\2\2\2\27\3\2\2\2\2\31\3\2\2\2")
-        buf.write(u"\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2\2\2!\3\2\2\2\2")
-        buf.write(u"#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+\3\2\2")
-        buf.write(u"\2\2-\3\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2\2\2\2")
-        buf.write(u"\65\3\2\2\2\2\67\3\2\2\2\29\3\2\2\2\2;\3\2\2\2\2=\3\2")
-        buf.write(u"\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2\2E\3\2\2\2\2G\3")
-        buf.write(u"\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2\2\2\2")
-        buf.write(u"Q\3\2\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3\2\2\2")
-        buf.write(u"\2[\3\2\2\2\2]\3\2\2\2\2_\3\2\2\2\2a\3\2\2\2\2c\3\2\2")
-        buf.write(u"\2\2e\3\2\2\2\2i\3\2\2\2\2k\3\2\2\2\2o\3\2\2\2\2q\3\2")
-        buf.write(u"\2\2\2s\3\2\2\2\2u\3\2\2\2\2w\3\2\2\2\2y\3\2\2\2\2{\3")
-        buf.write(u"\2\2\2\2}\3\2\2\2\3\177\3\2\2\2\5\u0082\3\2\2\2\7\u0088")
-        buf.write(u"\3\2\2\2\t\u008a\3\2\2\2\13\u008c\3\2\2\2\r\u008e\3\2")
-        buf.write(u"\2\2\17\u0090\3\2\2\2\21\u0092\3\2\2\2\23\u0094\3\2\2")
-        buf.write(u"\2\25\u0096\3\2\2\2\27\u0098\3\2\2\2\31\u009a\3\2\2\2")
-        buf.write(u"\33\u009c\3\2\2\2\35\u009e\3\2\2\2\37\u00da\3\2\2\2!")
-        buf.write(u"\u00dc\3\2\2\2#\u00e1\3\2\2\2%\u00e6\3\2\2\2\'\u00ec")
-        buf.write(u"\3\2\2\2)\u00f1\3\2\2\2+\u00f5\3\2\2\2-\u00fa\3\2\2\2")
-        buf.write(u"/\u00ff\3\2\2\2\61\u0104\3\2\2\2\63\u0109\3\2\2\2\65")
-        buf.write(u"\u010e\3\2\2\2\67\u0113\3\2\2\29\u011b\3\2\2\2;\u0123")
-        buf.write(u"\3\2\2\2=\u012b\3\2\2\2?\u0133\3\2\2\2A\u013b\3\2\2\2")
-        buf.write(u"C\u0143\3\2\2\2E\u0149\3\2\2\2G\u014f\3\2\2\2I\u0155")
-        buf.write(u"\3\2\2\2K\u015d\3\2\2\2M\u0165\3\2\2\2O\u016d\3\2\2\2")
-        buf.write(u"Q\u0173\3\2\2\2S\u017a\3\2\2\2U\u0180\3\2\2\2W\u0185")
-        buf.write(u"\3\2\2\2Y\u018b\3\2\2\2[\u0192\3\2\2\2]\u019a\3\2\2\2")
-        buf.write(u"_\u01a2\3\2\2\2a\u01aa\3\2\2\2c\u01ac\3\2\2\2e\u01ae")
-        buf.write(u"\3\2\2\2g\u01b0\3\2\2\2i\u01b2\3\2\2\2k\u01c2\3\2\2\2")
-        buf.write(u"m\u01c4\3\2\2\2o\u01eb\3\2\2\2q\u01ed\3\2\2\2s\u01ef")
-        buf.write(u"\3\2\2\2u\u01f1\3\2\2\2w\u01f6\3\2\2\2y\u01f8\3\2\2\2")
-        buf.write(u"{\u01fd\3\2\2\2}\u01ff\3\2\2\2\177\u0080\7.\2\2\u0080")
-        buf.write(u"\4\3\2\2\2\u0081\u0083\t\2\2\2\u0082\u0081\3\2\2\2\u0083")
-        buf.write(u"\u0084\3\2\2\2\u0084\u0082\3\2\2\2\u0084\u0085\3\2\2")
-        buf.write(u"\2\u0085\u0086\3\2\2\2\u0086\u0087\b\3\2\2\u0087\6\3")
-        buf.write(u"\2\2\2\u0088\u0089\7-\2\2\u0089\b\3\2\2\2\u008a\u008b")
-        buf.write(u"\7/\2\2\u008b\n\3\2\2\2\u008c\u008d\7,\2\2\u008d\f\3")
-        buf.write(u"\2\2\2\u008e\u008f\7\61\2\2\u008f\16\3\2\2\2\u0090\u0091")
-        buf.write(u"\7*\2\2\u0091\20\3\2\2\2\u0092\u0093\7+\2\2\u0093\22")
-        buf.write(u"\3\2\2\2\u0094\u0095\7}\2\2\u0095\24\3\2\2\2\u0096\u0097")
-        buf.write(u"\7\177\2\2\u0097\26\3\2\2\2\u0098\u0099\7]\2\2\u0099")
-        buf.write(u"\30\3\2\2\2\u009a\u009b\7_\2\2\u009b\32\3\2\2\2\u009c")
-        buf.write(u"\u009d\7~\2\2\u009d\34\3\2\2\2\u009e\u009f\7^\2\2\u009f")
-        buf.write(u"\u00a0\7n\2\2\u00a0\u00a1\7k\2\2\u00a1\u00a2\7o\2\2\u00a2")
-        buf.write(u"\36\3\2\2\2\u00a3\u00a4\7^\2\2\u00a4\u00a5\7v\2\2\u00a5")
-        buf.write(u"\u00db\7q\2\2\u00a6\u00a7\7^\2\2\u00a7\u00a8\7t\2\2\u00a8")
-        buf.write(u"\u00a9\7k\2\2\u00a9\u00aa\7i\2\2\u00aa\u00ab\7j\2\2\u00ab")
-        buf.write(u"\u00ac\7v\2\2\u00ac\u00ad\7c\2\2\u00ad\u00ae\7t\2\2\u00ae")
-        buf.write(u"\u00af\7t\2\2\u00af\u00b0\7q\2\2\u00b0\u00db\7y\2\2\u00b1")
-        buf.write(u"\u00b2\7^\2\2\u00b2\u00b3\7T\2\2\u00b3\u00b4\7k\2\2\u00b4")
-        buf.write(u"\u00b5\7i\2\2\u00b5\u00b6\7j\2\2\u00b6\u00b7\7v\2\2\u00b7")
-        buf.write(u"\u00b8\7c\2\2\u00b8\u00b9\7t\2\2\u00b9\u00ba\7t\2\2\u00ba")
-        buf.write(u"\u00bb\7q\2\2\u00bb\u00db\7y\2\2\u00bc\u00bd\7^\2\2\u00bd")
-        buf.write(u"\u00be\7n\2\2\u00be\u00bf\7q\2\2\u00bf\u00c0\7p\2\2\u00c0")
-        buf.write(u"\u00c1\7i\2\2\u00c1\u00c2\7t\2\2\u00c2\u00c3\7k\2\2\u00c3")
-        buf.write(u"\u00c4\7i\2\2\u00c4\u00c5\7j\2\2\u00c5\u00c6\7v\2\2\u00c6")
-        buf.write(u"\u00c7\7c\2\2\u00c7\u00c8\7t\2\2\u00c8\u00c9\7t\2\2\u00c9")
-        buf.write(u"\u00ca\7q\2\2\u00ca\u00db\7y\2\2\u00cb\u00cc\7^\2\2\u00cc")
-        buf.write(u"\u00cd\7N\2\2\u00cd\u00ce\7q\2\2\u00ce\u00cf\7p\2\2\u00cf")
-        buf.write(u"\u00d0\7i\2\2\u00d0\u00d1\7t\2\2\u00d1\u00d2\7k\2\2\u00d2")
-        buf.write(u"\u00d3\7i\2\2\u00d3\u00d4\7j\2\2\u00d4\u00d5\7v\2\2\u00d5")
-        buf.write(u"\u00d6\7c\2\2\u00d6\u00d7\7t\2\2\u00d7\u00d8\7t\2\2\u00d8")
-        buf.write(u"\u00d9\7q\2\2\u00d9\u00db\7y\2\2\u00da\u00a3\3\2\2\2")
-        buf.write(u"\u00da\u00a6\3\2\2\2\u00da\u00b1\3\2\2\2\u00da\u00bc")
-        buf.write(u"\3\2\2\2\u00da\u00cb\3\2\2\2\u00db \3\2\2\2\u00dc\u00dd")
-        buf.write(u"\7^\2\2\u00dd\u00de\7k\2\2\u00de\u00df\7p\2\2\u00df\u00e0")
-        buf.write(u"\7v\2\2\u00e0\"\3\2\2\2\u00e1\u00e2\7^\2\2\u00e2\u00e3")
-        buf.write(u"\7u\2\2\u00e3\u00e4\7w\2\2\u00e4\u00e5\7o\2\2\u00e5$")
-        buf.write(u"\3\2\2\2\u00e6\u00e7\7^\2\2\u00e7\u00e8\7r\2\2\u00e8")
-        buf.write(u"\u00e9\7t\2\2\u00e9\u00ea\7q\2\2\u00ea\u00eb\7f\2\2\u00eb")
-        buf.write(u"&\3\2\2\2\u00ec\u00ed\7^\2\2\u00ed\u00ee\7n\2\2\u00ee")
-        buf.write(u"\u00ef\7q\2\2\u00ef\u00f0\7i\2\2\u00f0(\3\2\2\2\u00f1")
-        buf.write(u"\u00f2\7^\2\2\u00f2\u00f3\7n\2\2\u00f3\u00f4\7p\2\2\u00f4")
-        buf.write(u"*\3\2\2\2\u00f5\u00f6\7^\2\2\u00f6\u00f7\7u\2\2\u00f7")
-        buf.write(u"\u00f8\7k\2\2\u00f8\u00f9\7p\2\2\u00f9,\3\2\2\2\u00fa")
-        buf.write(u"\u00fb\7^\2\2\u00fb\u00fc\7e\2\2\u00fc\u00fd\7q\2\2\u00fd")
-        buf.write(u"\u00fe\7u\2\2\u00fe.\3\2\2\2\u00ff\u0100\7^\2\2\u0100")
-        buf.write(u"\u0101\7v\2\2\u0101\u0102\7c\2\2\u0102\u0103\7p\2\2\u0103")
-        buf.write(u"\60\3\2\2\2\u0104\u0105\7^\2\2\u0105\u0106\7e\2\2\u0106")
-        buf.write(u"\u0107\7u\2\2\u0107\u0108\7e\2\2\u0108\62\3\2\2\2\u0109")
-        buf.write(u"\u010a\7^\2\2\u010a\u010b\7u\2\2\u010b\u010c\7g\2\2\u010c")
-        buf.write(u"\u010d\7e\2\2\u010d\64\3\2\2\2\u010e\u010f\7^\2\2\u010f")
-        buf.write(u"\u0110\7e\2\2\u0110\u0111\7q\2\2\u0111\u0112\7v\2\2\u0112")
-        buf.write(u"\66\3\2\2\2\u0113\u0114\7^\2\2\u0114\u0115\7c\2\2\u0115")
-        buf.write(u"\u0116\7t\2\2\u0116\u0117\7e\2\2\u0117\u0118\7u\2\2\u0118")
-        buf.write(u"\u0119\7k\2\2\u0119\u011a\7p\2\2\u011a8\3\2\2\2\u011b")
-        buf.write(u"\u011c\7^\2\2\u011c\u011d\7c\2\2\u011d\u011e\7t\2\2\u011e")
-        buf.write(u"\u011f\7e\2\2\u011f\u0120\7e\2\2\u0120\u0121\7q\2\2\u0121")
-        buf.write(u"\u0122\7u\2\2\u0122:\3\2\2\2\u0123\u0124\7^\2\2\u0124")
-        buf.write(u"\u0125\7c\2\2\u0125\u0126\7t\2\2\u0126\u0127\7e\2\2\u0127")
-        buf.write(u"\u0128\7v\2\2\u0128\u0129\7c\2\2\u0129\u012a\7p\2\2\u012a")
-        buf.write(u"<\3\2\2\2\u012b\u012c\7^\2\2\u012c\u012d\7c\2\2\u012d")
-        buf.write(u"\u012e\7t\2\2\u012e\u012f\7e\2\2\u012f\u0130\7e\2\2\u0130")
-        buf.write(u"\u0131\7u\2\2\u0131\u0132\7e\2\2\u0132>\3\2\2\2\u0133")
-        buf.write(u"\u0134\7^\2\2\u0134\u0135\7c\2\2\u0135\u0136\7t\2\2\u0136")
-        buf.write(u"\u0137\7e\2\2\u0137\u0138\7u\2\2\u0138\u0139\7g\2\2\u0139")
-        buf.write(u"\u013a\7e\2\2\u013a@\3\2\2\2\u013b\u013c\7^\2\2\u013c")
-        buf.write(u"\u013d\7c\2\2\u013d\u013e\7t\2\2\u013e\u013f\7e\2\2\u013f")
-        buf.write(u"\u0140\7e\2\2\u0140\u0141\7q\2\2\u0141\u0142\7v\2\2\u0142")
-        buf.write(u"B\3\2\2\2\u0143\u0144\7^\2\2\u0144\u0145\7u\2\2\u0145")
-        buf.write(u"\u0146\7k\2\2\u0146\u0147\7p\2\2\u0147\u0148\7j\2\2\u0148")
-        buf.write(u"D\3\2\2\2\u0149\u014a\7^\2\2\u014a\u014b\7e\2\2\u014b")
-        buf.write(u"\u014c\7q\2\2\u014c\u014d\7u\2\2\u014d\u014e\7j\2\2\u014e")
-        buf.write(u"F\3\2\2\2\u014f\u0150\7^\2\2\u0150\u0151\7v\2\2\u0151")
-        buf.write(u"\u0152\7c\2\2\u0152\u0153\7p\2\2\u0153\u0154\7j\2\2\u0154")
-        buf.write(u"H\3\2\2\2\u0155\u0156\7^\2\2\u0156\u0157\7c\2\2\u0157")
-        buf.write(u"\u0158\7t\2\2\u0158\u0159\7u\2\2\u0159\u015a\7k\2\2\u015a")
-        buf.write(u"\u015b\7p\2\2\u015b\u015c\7j\2\2\u015cJ\3\2\2\2\u015d")
-        buf.write(u"\u015e\7^\2\2\u015e\u015f\7c\2\2\u015f\u0160\7t\2\2\u0160")
-        buf.write(u"\u0161\7e\2\2\u0161\u0162\7q\2\2\u0162\u0163\7u\2\2\u0163")
-        buf.write(u"\u0164\7j\2\2\u0164L\3\2\2\2\u0165\u0166\7^\2\2\u0166")
-        buf.write(u"\u0167\7c\2\2\u0167\u0168\7t\2\2\u0168\u0169\7v\2\2\u0169")
-        buf.write(u"\u016a\7c\2\2\u016a\u016b\7p\2\2\u016b\u016c\7j\2\2\u016c")
-        buf.write(u"N\3\2\2\2\u016d\u016e\7^\2\2\u016e\u016f\7u\2\2\u016f")
-        buf.write(u"\u0170\7s\2\2\u0170\u0171\7t\2\2\u0171\u0172\7v\2\2\u0172")
-        buf.write(u"P\3\2\2\2\u0173\u0174\7^\2\2\u0174\u0175\7v\2\2\u0175")
-        buf.write(u"\u0176\7k\2\2\u0176\u0177\7o\2\2\u0177\u0178\7g\2\2\u0178")
-        buf.write(u"\u0179\7u\2\2\u0179R\3\2\2\2\u017a\u017b\7^\2\2\u017b")
-        buf.write(u"\u017c\7e\2\2\u017c\u017d\7f\2\2\u017d\u017e\7q\2\2\u017e")
-        buf.write(u"\u017f\7v\2\2\u017fT\3\2\2\2\u0180\u0181\7^\2\2\u0181")
-        buf.write(u"\u0182\7f\2\2\u0182\u0183\7k\2\2\u0183\u0184\7x\2\2\u0184")
-        buf.write(u"V\3\2\2\2\u0185\u0186\7^\2\2\u0186\u0187\7h\2\2\u0187")
-        buf.write(u"\u0188\7t\2\2\u0188\u0189\7c\2\2\u0189\u018a\7e\2\2\u018a")
-        buf.write(u"X\3\2\2\2\u018b\u018c\7^\2\2\u018c\u018d\7d\2\2\u018d")
-        buf.write(u"\u018e\7k\2\2\u018e\u018f\7p\2\2\u018f\u0190\7q\2\2\u0190")
-        buf.write(u"\u0191\7o\2\2\u0191Z\3\2\2\2\u0192\u0193\7^\2\2\u0193")
-        buf.write(u"\u0194\7f\2\2\u0194\u0195\7d\2\2\u0195\u0196\7k\2\2\u0196")
-        buf.write(u"\u0197\7p\2\2\u0197\u0198\7q\2\2\u0198\u0199\7o\2\2\u0199")
-        buf.write(u"\\\3\2\2\2\u019a\u019b\7^\2\2\u019b\u019c\7v\2\2\u019c")
-        buf.write(u"\u019d\7d\2\2\u019d\u019e\7k\2\2\u019e\u019f\7p\2\2\u019f")
-        buf.write(u"\u01a0\7q\2\2\u01a0\u01a1\7o\2\2\u01a1^\3\2\2\2\u01a2")
-        buf.write(u"\u01a3\7^\2\2\u01a3\u01a4\7o\2\2\u01a4\u01a5\7c\2\2\u01a5")
-        buf.write(u"\u01a6\7v\2\2\u01a6\u01a7\7j\2\2\u01a7\u01a8\7k\2\2\u01a8")
-        buf.write(u"\u01a9\7v\2\2\u01a9`\3\2\2\2\u01aa\u01ab\7a\2\2\u01ab")
-        buf.write(u"b\3\2\2\2\u01ac\u01ad\7`\2\2\u01add\3\2\2\2\u01ae\u01af")
-        buf.write(u"\7<\2\2\u01aff\3\2\2\2\u01b0\u01b1\t\2\2\2\u01b1h\3\2")
-        buf.write(u"\2\2\u01b2\u01b6\7f\2\2\u01b3\u01b5\5g\64\2\u01b4\u01b3")
-        buf.write(u"\3\2\2\2\u01b5\u01b8\3\2\2\2\u01b6\u01b7\3\2\2\2\u01b6")
-        buf.write(u"\u01b4\3\2\2\2\u01b7\u01c0\3\2\2\2\u01b8\u01b6\3\2\2")
-        buf.write(u"\2\u01b9\u01c1\t\3\2\2\u01ba\u01bc\7^\2\2\u01bb\u01bd")
-        buf.write(u"\t\3\2\2\u01bc\u01bb\3\2\2\2\u01bd\u01be\3\2\2\2\u01be")
-        buf.write(u"\u01bc\3\2\2\2\u01be\u01bf\3\2\2\2\u01bf\u01c1\3\2\2")
-        buf.write(u"\2\u01c0\u01b9\3\2\2\2\u01c0\u01ba\3\2\2\2\u01c1j\3\2")
-        buf.write(u"\2\2\u01c2\u01c3\t\3\2\2\u01c3l\3\2\2\2\u01c4\u01c5\t")
-        buf.write(u"\4\2\2\u01c5n\3\2\2\2\u01c6\u01c8\5m\67\2\u01c7\u01c6")
-        buf.write(u"\3\2\2\2\u01c8\u01c9\3\2\2\2\u01c9\u01c7\3\2\2\2\u01c9")
-        buf.write(u"\u01ca\3\2\2\2\u01ca\u01d2\3\2\2\2\u01cb\u01cc\7.\2\2")
-        buf.write(u"\u01cc\u01cd\5m\67\2\u01cd\u01ce\5m\67\2\u01ce\u01cf")
-        buf.write(u"\5m\67\2\u01cf\u01d1\3\2\2\2\u01d0\u01cb\3\2\2\2\u01d1")
-        buf.write(u"\u01d4\3\2\2\2\u01d2\u01d0\3\2\2\2\u01d2\u01d3\3\2\2")
-        buf.write(u"\2\u01d3\u01ec\3\2\2\2\u01d4\u01d2\3\2\2\2\u01d5\u01d7")
-        buf.write(u"\5m\67\2\u01d6\u01d5\3\2\2\2\u01d7\u01da\3\2\2\2\u01d8")
-        buf.write(u"\u01d6\3\2\2\2\u01d8\u01d9\3\2\2\2\u01d9\u01e2\3\2\2")
-        buf.write(u"\2\u01da\u01d8\3\2\2\2\u01db\u01dc\7.\2\2\u01dc\u01dd")
-        buf.write(u"\5m\67\2\u01dd\u01de\5m\67\2\u01de\u01df\5m\67\2\u01df")
-        buf.write(u"\u01e1\3\2\2\2\u01e0\u01db\3\2\2\2\u01e1\u01e4\3\2\2")
-        buf.write(u"\2\u01e2\u01e0\3\2\2\2\u01e2\u01e3\3\2\2\2\u01e3\u01e5")
-        buf.write(u"\3\2\2\2\u01e4\u01e2\3\2\2\2\u01e5\u01e7\7\60\2\2\u01e6")
-        buf.write(u"\u01e8\5m\67\2\u01e7\u01e6\3\2\2\2\u01e8\u01e9\3\2\2")
-        buf.write(u"\2\u01e9\u01e7\3\2\2\2\u01e9\u01ea\3\2\2\2\u01ea\u01ec")
-        buf.write(u"\3\2\2\2\u01eb\u01c7\3\2\2\2\u01eb\u01d8\3\2\2\2\u01ec")
-        buf.write(u"p\3\2\2\2\u01ed\u01ee\7?\2\2\u01eer\3\2\2\2\u01ef\u01f0")
-        buf.write(u"\7>\2\2\u01f0t\3\2\2\2\u01f1\u01f2\7^\2\2\u01f2\u01f3")
-        buf.write(u"\7n\2\2\u01f3\u01f4\7g\2\2\u01f4\u01f5\7s\2\2\u01f5v")
-        buf.write(u"\3\2\2\2\u01f6\u01f7\7@\2\2\u01f7x\3\2\2\2\u01f8\u01f9")
-        buf.write(u"\7^\2\2\u01f9\u01fa\7i\2\2\u01fa\u01fb\7g\2\2\u01fb\u01fc")
-        buf.write(u"\7s\2\2\u01fcz\3\2\2\2\u01fd\u01fe\7#\2\2\u01fe|\3\2")
-        buf.write(u"\2\2\u01ff\u0201\7^\2\2\u0200\u0202\t\3\2\2\u0201\u0200")
-        buf.write(u"\3\2\2\2\u0202\u0203\3\2\2\2\u0203\u0201\3\2\2\2\u0203")
-        buf.write(u"\u0204\3\2\2\2\u0204~\3\2\2\2\17\2\u0084\u00da\u01b6")
-        buf.write(u"\u01be\u01c0\u01c9\u01d2\u01d8\u01e2\u01e9\u01eb\u0203")
-        buf.write(u"\3\b\2\2")
+        buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00e7")
+        buf.write(u"\n\20\3\21\3\21\3\21\3\21\3\21\3\22\3\22\3\22\3\22\3")
+        buf.write(u"\22\3\23\3\23\3\23\3\23\3\23\3\23\3\24\3\24\3\24\3\24")
+        buf.write(u"\3\24\3\25\3\25\3\25\3\25\3\26\3\26\3\26\3\26\3\26\3")
+        buf.write(u"\27\3\27\3\27\3\27\3\27\3\30\3\30\3\30\3\30\3\30\3\31")
+        buf.write(u"\3\31\3\31\3\31\3\31\3\32\3\32\3\32\3\32\3\32\3\33\3")
+        buf.write(u"\33\3\33\3\33\3\33\3\34\3\34\3\34\3\34\3\34\3\34\3\34")
+        buf.write(u"\3\34\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\36\3")
+        buf.write(u"\36\3\36\3\36\3\36\3\36\3\36\3\36\3\37\3\37\3\37\3\37")
+        buf.write(u"\3\37\3\37\3\37\3\37\3 \3 \3 \3 \3 \3 \3 \3 \3!\3!\3")
+        buf.write(u"!\3!\3!\3!\3!\3!\3\"\3\"\3\"\3\"\3\"\3\"\3#\3#\3#\3#")
+        buf.write(u"\3#\3#\3$\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\3%\3&\3&\3&\3")
+        buf.write(u"&\3&\3&\3\'\3\'\3\'\3\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3(")
+        buf.write(u"\3(\3)\3)\3)\3)\3)\3)\3)\3)\3*\3*\3*\3*\3*\3*\3*\3*\3")
+        buf.write(u"+\3+\3+\3+\3+\3+\3+\3+\3,\3,\3,\3,\3,\3,\3,\3,\3-\3-")
+        buf.write(u"\3-\3-\3-\3-\3-\3-\3.\3.\3.\3.\3.\3.\3/\3/\3/\3/\3/\3")
+        buf.write(u"/\3/\3\60\3\60\3\60\3\60\3\60\3\60\3\61\3\61\3\61\3\61")
+        buf.write(u"\3\61\3\62\3\62\3\62\3\62\3\62\3\62\3\63\3\63\3\63\3")
+        buf.write(u"\63\3\63\3\63\3\63\3\64\3\64\3\64\3\64\3\64\3\64\3\64")
+        buf.write(u"\3\64\3\65\3\65\3\65\3\65\3\65\3\65\3\65\3\65\3\66\3")
+        buf.write(u"\66\3\66\3\66\3\66\3\66\3\66\3\66\3\67\3\67\38\38\39")
+        buf.write(u"\39\3:\3:\3;\3;\7;\u01eb\n;\f;\16;\u01ee\13;\3;\3;\3")
+        buf.write(u";\6;\u01f3\n;\r;\16;\u01f4\5;\u01f7\n;\3<\3<\3=\3=\3")
+        buf.write(u">\6>\u01fe\n>\r>\16>\u01ff\3>\3>\3>\3>\3>\7>\u0207\n")
+        buf.write(u">\f>\16>\u020a\13>\3>\7>\u020d\n>\f>\16>\u0210\13>\3")
+        buf.write(u">\3>\3>\3>\3>\7>\u0217\n>\f>\16>\u021a\13>\3>\3>\6>\u021e")
+        buf.write(u"\n>\r>\16>\u021f\5>\u0222\n>\3?\3?\3@\3@\3A\3A\3A\3A")
+        buf.write(u"\3A\3B\3B\3C\3C\3C\3C\3C\3D\3D\3E\3E\6E\u0238\nE\rE\16")
+        buf.write(u"E\u0239\3\u01ec\2F\3\3\5\4\7\5\t\6\13\7\r\b\17\t\21\n")
+        buf.write(u"\23\13\25\f\27\r\31\16\33\17\35\20\37\21!\22#\23%\24")
+        buf.write(u"\'\25)\26+\27-\30/\31\61\32\63\33\65\34\67\359\36;\37")
+        buf.write(u"= ?!A\"C#E$G%I&K\'M(O)Q*S+U,W-Y.[/]\60_\61a\62c\63e\64")
+        buf.write(u"g\65i\66k\67m8o9q:s\2u;w<y\2{=}>\177?\u0081@\u0083A\u0085")
+        buf.write(u"B\u0087C\u0089D\3\2\5\5\2\13\f\17\17\"\"\4\2C\\c|\3\2")
+        buf.write(u"\62;\2\u0247\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t")
+        buf.write(u"\3\2\2\2\2\13\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3")
+        buf.write(u"\2\2\2\2\23\3\2\2\2\2\25\3\2\2\2\2\27\3\2\2\2\2\31\3")
+        buf.write(u"\2\2\2\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2\2\2!\3\2")
+        buf.write(u"\2\2\2#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+")
+        buf.write(u"\3\2\2\2\2-\3\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2")
+        buf.write(u"\2\2\2\65\3\2\2\2\2\67\3\2\2\2\29\3\2\2\2\2;\3\2\2\2")
+        buf.write(u"\2=\3\2\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2\2E\3\2\2")
+        buf.write(u"\2\2G\3\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2")
+        buf.write(u"\2\2\2Q\3\2\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3")
+        buf.write(u"\2\2\2\2[\3\2\2\2\2]\3\2\2\2\2_\3\2\2\2\2a\3\2\2\2\2")
+        buf.write(u"c\3\2\2\2\2e\3\2\2\2\2g\3\2\2\2\2i\3\2\2\2\2k\3\2\2\2")
+        buf.write(u"\2m\3\2\2\2\2o\3\2\2\2\2q\3\2\2\2\2u\3\2\2\2\2w\3\2\2")
+        buf.write(u"\2\2{\3\2\2\2\2}\3\2\2\2\2\177\3\2\2\2\2\u0081\3\2\2")
+        buf.write(u"\2\2\u0083\3\2\2\2\2\u0085\3\2\2\2\2\u0087\3\2\2\2\2")
+        buf.write(u"\u0089\3\2\2\2\3\u008b\3\2\2\2\5\u008e\3\2\2\2\7\u0094")
+        buf.write(u"\3\2\2\2\t\u0096\3\2\2\2\13\u0098\3\2\2\2\r\u009a\3\2")
+        buf.write(u"\2\2\17\u009c\3\2\2\2\21\u009e\3\2\2\2\23\u00a0\3\2\2")
+        buf.write(u"\2\25\u00a2\3\2\2\2\27\u00a4\3\2\2\2\31\u00a6\3\2\2\2")
+        buf.write(u"\33\u00a8\3\2\2\2\35\u00aa\3\2\2\2\37\u00e6\3\2\2\2!")
+        buf.write(u"\u00e8\3\2\2\2#\u00ed\3\2\2\2%\u00f2\3\2\2\2\'\u00f8")
+        buf.write(u"\3\2\2\2)\u00fd\3\2\2\2+\u0101\3\2\2\2-\u0106\3\2\2\2")
+        buf.write(u"/\u010b\3\2\2\2\61\u0110\3\2\2\2\63\u0115\3\2\2\2\65")
+        buf.write(u"\u011a\3\2\2\2\67\u011f\3\2\2\29\u0127\3\2\2\2;\u012f")
+        buf.write(u"\3\2\2\2=\u0137\3\2\2\2?\u013f\3\2\2\2A\u0147\3\2\2\2")
+        buf.write(u"C\u014f\3\2\2\2E\u0155\3\2\2\2G\u015b\3\2\2\2I\u0161")
+        buf.write(u"\3\2\2\2K\u0167\3\2\2\2M\u016d\3\2\2\2O\u0173\3\2\2\2")
+        buf.write(u"Q\u017b\3\2\2\2S\u0183\3\2\2\2U\u018b\3\2\2\2W\u0193")
+        buf.write(u"\3\2\2\2Y\u019b\3\2\2\2[\u01a3\3\2\2\2]\u01a9\3\2\2\2")
+        buf.write(u"_\u01b0\3\2\2\2a\u01b6\3\2\2\2c\u01bb\3\2\2\2e\u01c1")
+        buf.write(u"\3\2\2\2g\u01c8\3\2\2\2i\u01d0\3\2\2\2k\u01d8\3\2\2\2")
+        buf.write(u"m\u01e0\3\2\2\2o\u01e2\3\2\2\2q\u01e4\3\2\2\2s\u01e6")
+        buf.write(u"\3\2\2\2u\u01e8\3\2\2\2w\u01f8\3\2\2\2y\u01fa\3\2\2\2")
+        buf.write(u"{\u0221\3\2\2\2}\u0223\3\2\2\2\177\u0225\3\2\2\2\u0081")
+        buf.write(u"\u0227\3\2\2\2\u0083\u022c\3\2\2\2\u0085\u022e\3\2\2")
+        buf.write(u"\2\u0087\u0233\3\2\2\2\u0089\u0235\3\2\2\2\u008b\u008c")
+        buf.write(u"\7.\2\2\u008c\4\3\2\2\2\u008d\u008f\t\2\2\2\u008e\u008d")
+        buf.write(u"\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u008e\3\2\2\2\u0090")
+        buf.write(u"\u0091\3\2\2\2\u0091\u0092\3\2\2\2\u0092\u0093\b\3\2")
+        buf.write(u"\2\u0093\6\3\2\2\2\u0094\u0095\7-\2\2\u0095\b\3\2\2\2")
+        buf.write(u"\u0096\u0097\7/\2\2\u0097\n\3\2\2\2\u0098\u0099\7,\2")
+        buf.write(u"\2\u0099\f\3\2\2\2\u009a\u009b\7\61\2\2\u009b\16\3\2")
+        buf.write(u"\2\2\u009c\u009d\7*\2\2\u009d\20\3\2\2\2\u009e\u009f")
+        buf.write(u"\7+\2\2\u009f\22\3\2\2\2\u00a0\u00a1\7}\2\2\u00a1\24")
+        buf.write(u"\3\2\2\2\u00a2\u00a3\7\177\2\2\u00a3\26\3\2\2\2\u00a4")
+        buf.write(u"\u00a5\7]\2\2\u00a5\30\3\2\2\2\u00a6\u00a7\7_\2\2\u00a7")
+        buf.write(u"\32\3\2\2\2\u00a8\u00a9\7~\2\2\u00a9\34\3\2\2\2\u00aa")
+        buf.write(u"\u00ab\7^\2\2\u00ab\u00ac\7n\2\2\u00ac\u00ad\7k\2\2\u00ad")
+        buf.write(u"\u00ae\7o\2\2\u00ae\36\3\2\2\2\u00af\u00b0\7^\2\2\u00b0")
+        buf.write(u"\u00b1\7v\2\2\u00b1\u00e7\7q\2\2\u00b2\u00b3\7^\2\2\u00b3")
+        buf.write(u"\u00b4\7t\2\2\u00b4\u00b5\7k\2\2\u00b5\u00b6\7i\2\2\u00b6")
+        buf.write(u"\u00b7\7j\2\2\u00b7\u00b8\7v\2\2\u00b8\u00b9\7c\2\2\u00b9")
+        buf.write(u"\u00ba\7t\2\2\u00ba\u00bb\7t\2\2\u00bb\u00bc\7q\2\2\u00bc")
+        buf.write(u"\u00e7\7y\2\2\u00bd\u00be\7^\2\2\u00be\u00bf\7T\2\2\u00bf")
+        buf.write(u"\u00c0\7k\2\2\u00c0\u00c1\7i\2\2\u00c1\u00c2\7j\2\2\u00c2")
+        buf.write(u"\u00c3\7v\2\2\u00c3\u00c4\7c\2\2\u00c4\u00c5\7t\2\2\u00c5")
+        buf.write(u"\u00c6\7t\2\2\u00c6\u00c7\7q\2\2\u00c7\u00e7\7y\2\2\u00c8")
+        buf.write(u"\u00c9\7^\2\2\u00c9\u00ca\7n\2\2\u00ca\u00cb\7q\2\2\u00cb")
+        buf.write(u"\u00cc\7p\2\2\u00cc\u00cd\7i\2\2\u00cd\u00ce\7t\2\2\u00ce")
+        buf.write(u"\u00cf\7k\2\2\u00cf\u00d0\7i\2\2\u00d0\u00d1\7j\2\2\u00d1")
+        buf.write(u"\u00d2\7v\2\2\u00d2\u00d3\7c\2\2\u00d3\u00d4\7t\2\2\u00d4")
+        buf.write(u"\u00d5\7t\2\2\u00d5\u00d6\7q\2\2\u00d6\u00e7\7y\2\2\u00d7")
+        buf.write(u"\u00d8\7^\2\2\u00d8\u00d9\7N\2\2\u00d9\u00da\7q\2\2\u00da")
+        buf.write(u"\u00db\7p\2\2\u00db\u00dc\7i\2\2\u00dc\u00dd\7t\2\2\u00dd")
+        buf.write(u"\u00de\7k\2\2\u00de\u00df\7i\2\2\u00df\u00e0\7j\2\2\u00e0")
+        buf.write(u"\u00e1\7v\2\2\u00e1\u00e2\7c\2\2\u00e2\u00e3\7t\2\2\u00e3")
+        buf.write(u"\u00e4\7t\2\2\u00e4\u00e5\7q\2\2\u00e5\u00e7\7y\2\2\u00e6")
+        buf.write(u"\u00af\3\2\2\2\u00e6\u00b2\3\2\2\2\u00e6\u00bd\3\2\2")
+        buf.write(u"\2\u00e6\u00c8\3\2\2\2\u00e6\u00d7\3\2\2\2\u00e7 \3\2")
+        buf.write(u"\2\2\u00e8\u00e9\7^\2\2\u00e9\u00ea\7k\2\2\u00ea\u00eb")
+        buf.write(u"\7p\2\2\u00eb\u00ec\7v\2\2\u00ec\"\3\2\2\2\u00ed\u00ee")
+        buf.write(u"\7^\2\2\u00ee\u00ef\7u\2\2\u00ef\u00f0\7w\2\2\u00f0\u00f1")
+        buf.write(u"\7o\2\2\u00f1$\3\2\2\2\u00f2\u00f3\7^\2\2\u00f3\u00f4")
+        buf.write(u"\7r\2\2\u00f4\u00f5\7t\2\2\u00f5\u00f6\7q\2\2\u00f6\u00f7")
+        buf.write(u"\7f\2\2\u00f7&\3\2\2\2\u00f8\u00f9\7^\2\2\u00f9\u00fa")
+        buf.write(u"\7n\2\2\u00fa\u00fb\7q\2\2\u00fb\u00fc\7i\2\2\u00fc(")
+        buf.write(u"\3\2\2\2\u00fd\u00fe\7^\2\2\u00fe\u00ff\7n\2\2\u00ff")
+        buf.write(u"\u0100\7p\2\2\u0100*\3\2\2\2\u0101\u0102\7^\2\2\u0102")
+        buf.write(u"\u0103\7u\2\2\u0103\u0104\7k\2\2\u0104\u0105\7p\2\2\u0105")
+        buf.write(u",\3\2\2\2\u0106\u0107\7^\2\2\u0107\u0108\7e\2\2\u0108")
+        buf.write(u"\u0109\7q\2\2\u0109\u010a\7u\2\2\u010a.\3\2\2\2\u010b")
+        buf.write(u"\u010c\7^\2\2\u010c\u010d\7v\2\2\u010d\u010e\7c\2\2\u010e")
+        buf.write(u"\u010f\7p\2\2\u010f\60\3\2\2\2\u0110\u0111\7^\2\2\u0111")
+        buf.write(u"\u0112\7e\2\2\u0112\u0113\7u\2\2\u0113\u0114\7e\2\2\u0114")
+        buf.write(u"\62\3\2\2\2\u0115\u0116\7^\2\2\u0116\u0117\7u\2\2\u0117")
+        buf.write(u"\u0118\7g\2\2\u0118\u0119\7e\2\2\u0119\64\3\2\2\2\u011a")
+        buf.write(u"\u011b\7^\2\2\u011b\u011c\7e\2\2\u011c\u011d\7q\2\2\u011d")
+        buf.write(u"\u011e\7v\2\2\u011e\66\3\2\2\2\u011f\u0120\7^\2\2\u0120")
+        buf.write(u"\u0121\7c\2\2\u0121\u0122\7t\2\2\u0122\u0123\7e\2\2\u0123")
+        buf.write(u"\u0124\7u\2\2\u0124\u0125\7k\2\2\u0125\u0126\7p\2\2\u0126")
+        buf.write(u"8\3\2\2\2\u0127\u0128\7^\2\2\u0128\u0129\7c\2\2\u0129")
+        buf.write(u"\u012a\7t\2\2\u012a\u012b\7e\2\2\u012b\u012c\7e\2\2\u012c")
+        buf.write(u"\u012d\7q\2\2\u012d\u012e\7u\2\2\u012e:\3\2\2\2\u012f")
+        buf.write(u"\u0130\7^\2\2\u0130\u0131\7c\2\2\u0131\u0132\7t\2\2\u0132")
+        buf.write(u"\u0133\7e\2\2\u0133\u0134\7v\2\2\u0134\u0135\7c\2\2\u0135")
+        buf.write(u"\u0136\7p\2\2\u0136<\3\2\2\2\u0137\u0138\7^\2\2\u0138")
+        buf.write(u"\u0139\7c\2\2\u0139\u013a\7t\2\2\u013a\u013b\7e\2\2\u013b")
+        buf.write(u"\u013c\7e\2\2\u013c\u013d\7u\2\2\u013d\u013e\7e\2\2\u013e")
+        buf.write(u">\3\2\2\2\u013f\u0140\7^\2\2\u0140\u0141\7c\2\2\u0141")
+        buf.write(u"\u0142\7t\2\2\u0142\u0143\7e\2\2\u0143\u0144\7u\2\2\u0144")
+        buf.write(u"\u0145\7g\2\2\u0145\u0146\7e\2\2\u0146@\3\2\2\2\u0147")
+        buf.write(u"\u0148\7^\2\2\u0148\u0149\7c\2\2\u0149\u014a\7t\2\2\u014a")
+        buf.write(u"\u014b\7e\2\2\u014b\u014c\7e\2\2\u014c\u014d\7q\2\2\u014d")
+        buf.write(u"\u014e\7v\2\2\u014eB\3\2\2\2\u014f\u0150\7^\2\2\u0150")
+        buf.write(u"\u0151\7u\2\2\u0151\u0152\7k\2\2\u0152\u0153\7p\2\2\u0153")
+        buf.write(u"\u0154\7j\2\2\u0154D\3\2\2\2\u0155\u0156\7^\2\2\u0156")
+        buf.write(u"\u0157\7e\2\2\u0157\u0158\7q\2\2\u0158\u0159\7u\2\2\u0159")
+        buf.write(u"\u015a\7j\2\2\u015aF\3\2\2\2\u015b\u015c\7^\2\2\u015c")
+        buf.write(u"\u015d\7v\2\2\u015d\u015e\7c\2\2\u015e\u015f\7p\2\2\u015f")
+        buf.write(u"\u0160\7j\2\2\u0160H\3\2\2\2\u0161\u0162\7^\2\2\u0162")
+        buf.write(u"\u0163\7e\2\2\u0163\u0164\7u\2\2\u0164\u0165\7e\2\2\u0165")
+        buf.write(u"\u0166\7j\2\2\u0166J\3\2\2\2\u0167\u0168\7^\2\2\u0168")
+        buf.write(u"\u0169\7u\2\2\u0169\u016a\7g\2\2\u016a\u016b\7e\2\2\u016b")
+        buf.write(u"\u016c\7j\2\2\u016cL\3\2\2\2\u016d\u016e\7^\2\2\u016e")
+        buf.write(u"\u016f\7e\2\2\u016f\u0170\7q\2\2\u0170\u0171\7v\2\2\u0171")
+        buf.write(u"\u0172\7j\2\2\u0172N\3\2\2\2\u0173\u0174\7^\2\2\u0174")
+        buf.write(u"\u0175\7c\2\2\u0175\u0176\7t\2\2\u0176\u0177\7u\2\2\u0177")
+        buf.write(u"\u0178\7k\2\2\u0178\u0179\7p\2\2\u0179\u017a\7j\2\2\u017a")
+        buf.write(u"P\3\2\2\2\u017b\u017c\7^\2\2\u017c\u017d\7c\2\2\u017d")
+        buf.write(u"\u017e\7t\2\2\u017e\u017f\7e\2\2\u017f\u0180\7q\2\2\u0180")
+        buf.write(u"\u0181\7u\2\2\u0181\u0182\7j\2\2\u0182R\3\2\2\2\u0183")
+        buf.write(u"\u0184\7^\2\2\u0184\u0185\7c\2\2\u0185\u0186\7t\2\2\u0186")
+        buf.write(u"\u0187\7v\2\2\u0187\u0188\7c\2\2\u0188\u0189\7p\2\2\u0189")
+        buf.write(u"\u018a\7j\2\2\u018aT\3\2\2\2\u018b\u018c\7^\2\2\u018c")
+        buf.write(u"\u018d\7c\2\2\u018d\u018e\7t\2\2\u018e\u018f\7e\2\2\u018f")
+        buf.write(u"\u0190\7u\2\2\u0190\u0191\7e\2\2\u0191\u0192\7j\2\2\u0192")
+        buf.write(u"V\3\2\2\2\u0193\u0194\7^\2\2\u0194\u0195\7c\2\2\u0195")
+        buf.write(u"\u0196\7t\2\2\u0196\u0197\7u\2\2\u0197\u0198\7g\2\2\u0198")
+        buf.write(u"\u0199\7e\2\2\u0199\u019a\7j\2\2\u019aX\3\2\2\2\u019b")
+        buf.write(u"\u019c\7^\2\2\u019c\u019d\7c\2\2\u019d\u019e\7t\2\2\u019e")
+        buf.write(u"\u019f\7e\2\2\u019f\u01a0\7q\2\2\u01a0\u01a1\7v\2\2\u01a1")
+        buf.write(u"\u01a2\7j\2\2\u01a2Z\3\2\2\2\u01a3\u01a4\7^\2\2\u01a4")
+        buf.write(u"\u01a5\7u\2\2\u01a5\u01a6\7s\2\2\u01a6\u01a7\7t\2\2\u01a7")
+        buf.write(u"\u01a8\7v\2\2\u01a8\\\3\2\2\2\u01a9\u01aa\7^\2\2\u01aa")
+        buf.write(u"\u01ab\7v\2\2\u01ab\u01ac\7k\2\2\u01ac\u01ad\7o\2\2\u01ad")
+        buf.write(u"\u01ae\7g\2\2\u01ae\u01af\7u\2\2\u01af^\3\2\2\2\u01b0")
+        buf.write(u"\u01b1\7^\2\2\u01b1\u01b2\7e\2\2\u01b2\u01b3\7f\2\2\u01b3")
+        buf.write(u"\u01b4\7q\2\2\u01b4\u01b5\7v\2\2\u01b5`\3\2\2\2\u01b6")
+        buf.write(u"\u01b7\7^\2\2\u01b7\u01b8\7f\2\2\u01b8\u01b9\7k\2\2\u01b9")
+        buf.write(u"\u01ba\7x\2\2\u01bab\3\2\2\2\u01bb\u01bc\7^\2\2\u01bc")
+        buf.write(u"\u01bd\7h\2\2\u01bd\u01be\7t\2\2\u01be\u01bf\7c\2\2\u01bf")
+        buf.write(u"\u01c0\7e\2\2\u01c0d\3\2\2\2\u01c1\u01c2\7^\2\2\u01c2")
+        buf.write(u"\u01c3\7d\2\2\u01c3\u01c4\7k\2\2\u01c4\u01c5\7p\2\2\u01c5")
+        buf.write(u"\u01c6\7q\2\2\u01c6\u01c7\7o\2\2\u01c7f\3\2\2\2\u01c8")
+        buf.write(u"\u01c9\7^\2\2\u01c9\u01ca\7f\2\2\u01ca\u01cb\7d\2\2\u01cb")
+        buf.write(u"\u01cc\7k\2\2\u01cc\u01cd\7p\2\2\u01cd\u01ce\7q\2\2\u01ce")
+        buf.write(u"\u01cf\7o\2\2\u01cfh\3\2\2\2\u01d0\u01d1\7^\2\2\u01d1")
+        buf.write(u"\u01d2\7v\2\2\u01d2\u01d3\7d\2\2\u01d3\u01d4\7k\2\2\u01d4")
+        buf.write(u"\u01d5\7p\2\2\u01d5\u01d6\7q\2\2\u01d6\u01d7\7o\2\2\u01d7")
+        buf.write(u"j\3\2\2\2\u01d8\u01d9\7^\2\2\u01d9\u01da\7o\2\2\u01da")
+        buf.write(u"\u01db\7c\2\2\u01db\u01dc\7v\2\2\u01dc\u01dd\7j\2\2\u01dd")
+        buf.write(u"\u01de\7k\2\2\u01de\u01df\7v\2\2\u01dfl\3\2\2\2\u01e0")
+        buf.write(u"\u01e1\7a\2\2\u01e1n\3\2\2\2\u01e2\u01e3\7`\2\2\u01e3")
+        buf.write(u"p\3\2\2\2\u01e4\u01e5\7<\2\2\u01e5r\3\2\2\2\u01e6\u01e7")
+        buf.write(u"\t\2\2\2\u01e7t\3\2\2\2\u01e8\u01ec\7f\2\2\u01e9\u01eb")
+        buf.write(u"\5s:\2\u01ea\u01e9\3\2\2\2\u01eb\u01ee\3\2\2\2\u01ec")
+        buf.write(u"\u01ed\3\2\2\2\u01ec\u01ea\3\2\2\2\u01ed\u01f6\3\2\2")
+        buf.write(u"\2\u01ee\u01ec\3\2\2\2\u01ef\u01f7\t\3\2\2\u01f0\u01f2")
+        buf.write(u"\7^\2\2\u01f1\u01f3\t\3\2\2\u01f2\u01f1\3\2\2\2\u01f3")
+        buf.write(u"\u01f4\3\2\2\2\u01f4\u01f2\3\2\2\2\u01f4\u01f5\3\2\2")
+        buf.write(u"\2\u01f5\u01f7\3\2\2\2\u01f6\u01ef\3\2\2\2\u01f6\u01f0")
+        buf.write(u"\3\2\2\2\u01f7v\3\2\2\2\u01f8\u01f9\t\3\2\2\u01f9x\3")
+        buf.write(u"\2\2\2\u01fa\u01fb\t\4\2\2\u01fbz\3\2\2\2\u01fc\u01fe")
+        buf.write(u"\5y=\2\u01fd\u01fc\3\2\2\2\u01fe\u01ff\3\2\2\2\u01ff")
+        buf.write(u"\u01fd\3\2\2\2\u01ff\u0200\3\2\2\2\u0200\u0208\3\2\2")
+        buf.write(u"\2\u0201\u0202\7.\2\2\u0202\u0203\5y=\2\u0203\u0204\5")
+        buf.write(u"y=\2\u0204\u0205\5y=\2\u0205\u0207\3\2\2\2\u0206\u0201")
+        buf.write(u"\3\2\2\2\u0207\u020a\3\2\2\2\u0208\u0206\3\2\2\2\u0208")
+        buf.write(u"\u0209\3\2\2\2\u0209\u0222\3\2\2\2\u020a\u0208\3\2\2")
+        buf.write(u"\2\u020b\u020d\5y=\2\u020c\u020b\3\2\2\2\u020d\u0210")
+        buf.write(u"\3\2\2\2\u020e\u020c\3\2\2\2\u020e\u020f\3\2\2\2\u020f")
+        buf.write(u"\u0218\3\2\2\2\u0210\u020e\3\2\2\2\u0211\u0212\7.\2\2")
+        buf.write(u"\u0212\u0213\5y=\2\u0213\u0214\5y=\2\u0214\u0215\5y=")
+        buf.write(u"\2\u0215\u0217\3\2\2\2\u0216\u0211\3\2\2\2\u0217\u021a")
+        buf.write(u"\3\2\2\2\u0218\u0216\3\2\2\2\u0218\u0219\3\2\2\2\u0219")
+        buf.write(u"\u021b\3\2\2\2\u021a\u0218\3\2\2\2\u021b\u021d\7\60\2")
+        buf.write(u"\2\u021c\u021e\5y=\2\u021d\u021c\3\2\2\2\u021e\u021f")
+        buf.write(u"\3\2\2\2\u021f\u021d\3\2\2\2\u021f\u0220\3\2\2\2\u0220")
+        buf.write(u"\u0222\3\2\2\2\u0221\u01fd\3\2\2\2\u0221\u020e\3\2\2")
+        buf.write(u"\2\u0222|\3\2\2\2\u0223\u0224\7?\2\2\u0224~\3\2\2\2\u0225")
+        buf.write(u"\u0226\7>\2\2\u0226\u0080\3\2\2\2\u0227\u0228\7^\2\2")
+        buf.write(u"\u0228\u0229\7n\2\2\u0229\u022a\7g\2\2\u022a\u022b\7")
+        buf.write(u"s\2\2\u022b\u0082\3\2\2\2\u022c\u022d\7@\2\2\u022d\u0084")
+        buf.write(u"\3\2\2\2\u022e\u022f\7^\2\2\u022f\u0230\7i\2\2\u0230")
+        buf.write(u"\u0231\7g\2\2\u0231\u0232\7s\2\2\u0232\u0086\3\2\2\2")
+        buf.write(u"\u0233\u0234\7#\2\2\u0234\u0088\3\2\2\2\u0235\u0237\7")
+        buf.write(u"^\2\2\u0236\u0238\t\3\2\2\u0237\u0236\3\2\2\2\u0238\u0239")
+        buf.write(u"\3\2\2\2\u0239\u0237\3\2\2\2\u0239\u023a\3\2\2\2\u023a")
+        buf.write(u"\u008a\3\2\2\2\17\2\u0090\u00e6\u01ec\u01f4\u01f6\u01ff")
+        buf.write(u"\u0208\u020e\u0218\u021f\u0221\u0239\3\b\2\2")
         return buf.getvalue()
 
 
@@ -283,31 +306,37 @@ class LaTeXLexer(Lexer):
     FUNC_SINH = 33
     FUNC_COSH = 34
     FUNC_TANH = 35
-    FUNC_ARSINH = 36
-    FUNC_ARCOSH = 37
-    FUNC_ARTANH = 38
-    FUNC_SQRT = 39
-    CMD_TIMES = 40
-    CMD_CDOT = 41
-    CMD_DIV = 42
-    CMD_FRAC = 43
-    CMD_BINOM = 44
-    CMD_DBINOM = 45
-    CMD_TBINOM = 46
-    CMD_MATHIT = 47
-    UNDERSCORE = 48
-    CARET = 49
-    COLON = 50
-    DIFFERENTIAL = 51
-    LETTER = 52
-    NUMBER = 53
-    EQUAL = 54
-    LT = 55
-    LTE = 56
-    GT = 57
-    GTE = 58
-    BANG = 59
-    SYMBOL = 60
+    FUNC_CSCH = 36
+    FUNC_SECH = 37
+    FUNC_COTH = 38
+    FUNC_ARSINH = 39
+    FUNC_ARCOSH = 40
+    FUNC_ARTANH = 41
+    FUNC_ARCSCH = 42
+    FUNC_ARSECH = 43
+    FUNC_ARCOTH = 44
+    FUNC_SQRT = 45
+    CMD_TIMES = 46
+    CMD_CDOT = 47
+    CMD_DIV = 48
+    CMD_FRAC = 49
+    CMD_BINOM = 50
+    CMD_DBINOM = 51
+    CMD_TBINOM = 52
+    CMD_MATHIT = 53
+    UNDERSCORE = 54
+    CARET = 55
+    COLON = 56
+    DIFFERENTIAL = 57
+    LETTER = 58
+    NUMBER = 59
+    EQUAL = 60
+    LT = 61
+    LTE = 62
+    GT = 63
+    GTE = 64
+    BANG = 65
+    SYMBOL = 66
 
     channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
 
@@ -319,11 +348,12 @@ class LaTeXLexer(Lexer):
             u"'\\prod'", u"'\\log'", u"'\\ln'", u"'\\sin'", u"'\\cos'",
             u"'\\tan'", u"'\\csc'", u"'\\sec'", u"'\\cot'", u"'\\arcsin'",
             u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'", u"'\\arcsec'",
-            u"'\\arccot'", u"'\\sinh'", u"'\\cosh'", u"'\\tanh'", u"'\\arsinh'",
-            u"'\\arcosh'", u"'\\artanh'", u"'\\sqrt'", u"'\\times'", u"'\\cdot'",
-            u"'\\div'", u"'\\frac'", u"'\\binom'", u"'\\dbinom'", u"'\\tbinom'",
-            u"'\\mathit'", u"'_'", u"'^'", u"':'", u"'='", u"'<'", u"'\\leq'",
-            u"'>'", u"'\\geq'", u"'!'" ]
+            u"'\\arccot'", u"'\\sinh'", u"'\\cosh'", u"'\\tanh'", u"'\\csch'",
+            u"'\\sech'", u"'\\coth'", u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'",
+            u"'\\arcsch'", u"'\\arsech'", u"'\\arcoth'", u"'\\sqrt'", u"'\\times'",
+            u"'\\cdot'", u"'\\div'", u"'\\frac'", u"'\\binom'", u"'\\dbinom'",
+            u"'\\tbinom'", u"'\\mathit'", u"'_'", u"'^'", u"':'", u"'='",
+            u"'<'", u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
 
     symbolicNames = [ u"<INVALID>",
             u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN", u"R_PAREN",
@@ -332,12 +362,13 @@ class LaTeXLexer(Lexer):
             u"FUNC_PROD", u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN", u"FUNC_COS",
             u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT", u"FUNC_ARCSIN",
             u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC", u"FUNC_ARCSEC",
-            u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH", u"FUNC_TANH", u"FUNC_ARSINH",
-            u"FUNC_ARCOSH", u"FUNC_ARTANH", u"FUNC_SQRT", u"CMD_TIMES",
-            u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM",
-            u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE", u"CARET", u"COLON",
-            u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL", u"LT", u"LTE",
-            u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+            u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH", u"FUNC_TANH", u"FUNC_CSCH",
+            u"FUNC_SECH", u"FUNC_COTH", u"FUNC_ARSINH", u"FUNC_ARCOSH",
+            u"FUNC_ARTANH", u"FUNC_ARCSCH", u"FUNC_ARSECH", u"FUNC_ARCOTH",
+            u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC",
+            u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE",
+            u"CARET", u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL",
+            u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
 
     ruleNames = [ u"T__0", u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN",
                   u"R_PAREN", u"L_BRACE", u"R_BRACE", u"L_BRACKET", u"R_BRACKET",
@@ -346,18 +377,20 @@ class LaTeXLexer(Lexer):
                   u"FUNC_COS", u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT",
                   u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC",
                   u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH",
-                  u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH",
-                  u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC",
-                  u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM", u"CMD_MATHIT",
-                  u"UNDERSCORE", u"CARET", u"COLON", u"WS_CHAR", u"DIFFERENTIAL",
-                  u"LETTER", u"DIGIT", u"NUMBER", u"EQUAL", u"LT", u"LTE",
-                  u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                  u"FUNC_TANH", u"FUNC_CSCH", u"FUNC_SECH", u"FUNC_COTH",
+                  u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH", u"FUNC_ARCSCH",
+                  u"FUNC_ARSECH", u"FUNC_ARCOTH", u"FUNC_SQRT", u"CMD_TIMES",
+                  u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM",
+                  u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE", u"CARET",
+                  u"COLON", u"WS_CHAR", u"DIFFERENTIAL", u"LETTER", u"DIGIT",
+                  u"NUMBER", u"EQUAL", u"LT", u"LTE", u"GT", u"GTE", u"BANG",
+                  u"SYMBOL" ]
 
     grammarFileName = u"LaTeX.g4"
 
     def __init__(self, input=None, output=sys.stdout):
         super(LaTeXLexer, self).__init__(input, output=output)
-        self.checkVersion("4.7.1")
+        self.checkVersion("4.7.2")
         self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._actions = None
         self._predicates = None

--- a/sympy/parsing/latex/_antlr/latexparser.py
+++ b/sympy/parsing/latex/_antlr/latexparser.py
@@ -15,10 +15,11 @@ from antlr4 import *
 from io import StringIO
 import sys
 
+
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3")
-        buf.write(u">\u01ae\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t")
+        buf.write(u"D\u01ae\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t")
         buf.write(u"\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t\r")
         buf.write(u"\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22\4")
         buf.write(u"\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30")
@@ -62,10 +63,10 @@ def serializedATN():
         buf.write(u"!\3!\3\"\3\"\3\"\3\"\3\"\3\"\5\"\u019a\n\"\3#\3#\3#\3")
         buf.write(u"#\3#\3#\5#\u01a2\n#\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\3%")
         buf.write(u"\2\b\4\n\f\16 \"&\2\4\6\b\n\f\16\20\22\24\26\30\32\34")
-        buf.write(u"\36 \"$&(*,.\60\62\64\668:<>@BDFH\2\t\3\28<\3\2\5\6\5")
-        buf.write(u"\2\7\b*,\64\64\4\2\66\66>>\3\2.\60\3\2\25(\3\2\23\24")
-        buf.write(u"\2\u01c6\2J\3\2\2\2\4L\3\2\2\2\6W\3\2\2\2\b[\3\2\2\2")
-        buf.write(u"\n]\3\2\2\2\fh\3\2\2\2\16s\3\2\2\2\20\u0085\3\2\2\2\22")
+        buf.write(u"\36 \"$&(*,.\60\62\64\668:<>@BDFH\2\t\3\2>B\3\2\5\6\5")
+        buf.write(u"\2\7\b\60\62::\4\2<<DD\3\2\64\66\3\2\25.\3\2\23\24\2")
+        buf.write(u"\u01c6\2J\3\2\2\2\4L\3\2\2\2\6W\3\2\2\2\b[\3\2\2\2\n")
+        buf.write(u"]\3\2\2\2\fh\3\2\2\2\16s\3\2\2\2\20\u0085\3\2\2\2\22")
         buf.write(u"\u0090\3\2\2\2\24\u0092\3\2\2\2\26\u0099\3\2\2\2\30\u00a2")
         buf.write(u"\3\2\2\2\32\u00a4\3\2\2\2\34\u00ac\3\2\2\2\36\u00b4\3")
         buf.write(u"\2\2\2 \u00bc\3\2\2\2\"\u00d0\3\2\2\2$\u00ea\3\2\2\2")
@@ -77,7 +78,7 @@ def serializedATN():
         buf.write(u"H\u01a8\3\2\2\2JK\5\4\3\2K\3\3\2\2\2LM\b\3\1\2MN\5\b")
         buf.write(u"\5\2NT\3\2\2\2OP\f\4\2\2PQ\t\2\2\2QS\5\4\3\5RO\3\2\2")
         buf.write(u"\2SV\3\2\2\2TR\3\2\2\2TU\3\2\2\2U\5\3\2\2\2VT\3\2\2\2")
-        buf.write(u"WX\5\b\5\2XY\78\2\2YZ\5\b\5\2Z\7\3\2\2\2[\\\5\n\6\2\\")
+        buf.write(u"WX\5\b\5\2XY\7>\2\2YZ\5\b\5\2Z\7\3\2\2\2[\\\5\n\6\2\\")
         buf.write(u"\t\3\2\2\2]^\b\6\1\2^_\5\f\7\2_e\3\2\2\2`a\f\4\2\2ab")
         buf.write(u"\t\3\2\2bd\5\n\6\5c`\3\2\2\2dg\3\2\2\2ec\3\2\2\2ef\3")
         buf.write(u"\2\2\2f\13\3\2\2\2ge\3\2\2\2hi\b\7\1\2ij\5\20\t\2jp\3")
@@ -100,21 +101,21 @@ def serializedATN():
         buf.write(u"\"\22\2\u009a\u009c\5\30\r\2\u009b\u009a\3\2\2\2\u009c")
         buf.write(u"\u009f\3\2\2\2\u009d\u009b\3\2\2\2\u009d\u009e\3\2\2")
         buf.write(u"\2\u009e\27\3\2\2\2\u009f\u009d\3\2\2\2\u00a0\u00a3\7")
-        buf.write(u"=\2\2\u00a1\u00a3\5\32\16\2\u00a2\u00a0\3\2\2\2\u00a2")
+        buf.write(u"C\2\2\u00a1\u00a3\5\32\16\2\u00a2\u00a0\3\2\2\2\u00a2")
         buf.write(u"\u00a1\3\2\2\2\u00a3\31\3\2\2\2\u00a4\u00aa\7\17\2\2")
         buf.write(u"\u00a5\u00ab\5\36\20\2\u00a6\u00ab\5\34\17\2\u00a7\u00a8")
         buf.write(u"\5\36\20\2\u00a8\u00a9\5\34\17\2\u00a9\u00ab\3\2\2\2")
         buf.write(u"\u00aa\u00a5\3\2\2\2\u00aa\u00a6\3\2\2\2\u00aa\u00a7")
-        buf.write(u"\3\2\2\2\u00ab\33\3\2\2\2\u00ac\u00ad\7\62\2\2\u00ad")
-        buf.write(u"\u00b0\7\13\2\2\u00ae\u00b1\5\b\5\2\u00af\u00b1\5\6\4")
-        buf.write(u"\2\u00b0\u00ae\3\2\2\2\u00b0\u00af\3\2\2\2\u00b1\u00b2")
-        buf.write(u"\3\2\2\2\u00b2\u00b3\7\f\2\2\u00b3\35\3\2\2\2\u00b4\u00b5")
-        buf.write(u"\7\63\2\2\u00b5\u00b8\7\13\2\2\u00b6\u00b9\5\b\5\2\u00b7")
+        buf.write(u"\3\2\2\2\u00ab\33\3\2\2\2\u00ac\u00ad\78\2\2\u00ad\u00b0")
+        buf.write(u"\7\13\2\2\u00ae\u00b1\5\b\5\2\u00af\u00b1\5\6\4\2\u00b0")
+        buf.write(u"\u00ae\3\2\2\2\u00b0\u00af\3\2\2\2\u00b1\u00b2\3\2\2")
+        buf.write(u"\2\u00b2\u00b3\7\f\2\2\u00b3\35\3\2\2\2\u00b4\u00b5\7")
+        buf.write(u"9\2\2\u00b5\u00b8\7\13\2\2\u00b6\u00b9\5\b\5\2\u00b7")
         buf.write(u"\u00b9\5\6\4\2\u00b8\u00b6\3\2\2\2\u00b8\u00b7\3\2\2")
         buf.write(u"\2\u00b9\u00ba\3\2\2\2\u00ba\u00bb\7\f\2\2\u00bb\37\3")
         buf.write(u"\2\2\2\u00bc\u00bd\b\21\1\2\u00bd\u00be\5$\23\2\u00be")
-        buf.write(u"\u00cd\3\2\2\2\u00bf\u00c0\f\4\2\2\u00c0\u00c6\7\63\2")
-        buf.write(u"\2\u00c1\u00c7\5,\27\2\u00c2\u00c3\7\13\2\2\u00c3\u00c4")
+        buf.write(u"\u00cd\3\2\2\2\u00bf\u00c0\f\4\2\2\u00c0\u00c6\79\2\2")
+        buf.write(u"\u00c1\u00c7\5,\27\2\u00c2\u00c3\7\13\2\2\u00c3\u00c4")
         buf.write(u"\5\b\5\2\u00c4\u00c5\7\f\2\2\u00c5\u00c7\3\2\2\2\u00c6")
         buf.write(u"\u00c1\3\2\2\2\u00c6\u00c2\3\2\2\2\u00c7\u00c9\3\2\2")
         buf.write(u"\2\u00c8\u00ca\5B\"\2\u00c9\u00c8\3\2\2\2\u00c9\u00ca")
@@ -122,7 +123,7 @@ def serializedATN():
         buf.write(u"\u00cf\3\2\2\2\u00cd\u00cb\3\2\2\2\u00cd\u00ce\3\2\2")
         buf.write(u"\2\u00ce!\3\2\2\2\u00cf\u00cd\3\2\2\2\u00d0\u00d1\b\22")
         buf.write(u"\1\2\u00d1\u00d2\5&\24\2\u00d2\u00e1\3\2\2\2\u00d3\u00d4")
-        buf.write(u"\f\4\2\2\u00d4\u00da\7\63\2\2\u00d5\u00db\5,\27\2\u00d6")
+        buf.write(u"\f\4\2\2\u00d4\u00da\79\2\2\u00d5\u00db\5,\27\2\u00d6")
         buf.write(u"\u00d7\7\13\2\2\u00d7\u00d8\5\b\5\2\u00d8\u00d9\7\f\2")
         buf.write(u"\2\u00d9\u00db\3\2\2\2\u00da\u00d5\3\2\2\2\u00da\u00d6")
         buf.write(u"\3\2\2\2\u00db\u00dd\3\2\2\2\u00dc\u00de\5B\"\2\u00dd")
@@ -147,14 +148,14 @@ def serializedATN():
         buf.write(u"\2\2\u0101\u0102\7\17\2\2\u0102\u0103\5\b\5\2\u0103\u0104")
         buf.write(u"\7\17\2\2\u0104+\3\2\2\2\u0105\u0107\t\5\2\2\u0106\u0108")
         buf.write(u"\5B\"\2\u0107\u0106\3\2\2\2\u0107\u0108\3\2\2\2\u0108")
-        buf.write(u"\u010d\3\2\2\2\u0109\u010d\7\67\2\2\u010a\u010d\7\65")
-        buf.write(u"\2\2\u010b\u010d\5.\30\2\u010c\u0105\3\2\2\2\u010c\u0109")
+        buf.write(u"\u010d\3\2\2\2\u0109\u010d\7=\2\2\u010a\u010d\7;\2\2")
+        buf.write(u"\u010b\u010d\5.\30\2\u010c\u0105\3\2\2\2\u010c\u0109")
         buf.write(u"\3\2\2\2\u010c\u010a\3\2\2\2\u010c\u010b\3\2\2\2\u010d")
-        buf.write(u"-\3\2\2\2\u010e\u010f\7\61\2\2\u010f\u0110\7\13\2\2\u0110")
+        buf.write(u"-\3\2\2\2\u010e\u010f\7\67\2\2\u010f\u0110\7\13\2\2\u0110")
         buf.write(u"\u0111\5\60\31\2\u0111\u0112\7\f\2\2\u0112/\3\2\2\2\u0113")
-        buf.write(u"\u0115\7\66\2\2\u0114\u0113\3\2\2\2\u0115\u0118\3\2\2")
-        buf.write(u"\2\u0116\u0114\3\2\2\2\u0116\u0117\3\2\2\2\u0117\61\3")
-        buf.write(u"\2\2\2\u0118\u0116\3\2\2\2\u0119\u011a\7-\2\2\u011a\u011b")
+        buf.write(u"\u0115\7<\2\2\u0114\u0113\3\2\2\2\u0115\u0118\3\2\2\2")
+        buf.write(u"\u0116\u0114\3\2\2\2\u0116\u0117\3\2\2\2\u0117\61\3\2")
+        buf.write(u"\2\2\u0118\u0116\3\2\2\2\u0119\u011a\7\63\2\2\u011a\u011b")
         buf.write(u"\7\13\2\2\u011b\u011c\5\b\5\2\u011c\u011d\7\f\2\2\u011d")
         buf.write(u"\u011e\7\13\2\2\u011e\u011f\5\b\5\2\u011f\u0120\7\f\2")
         buf.write(u"\2\u0120\63\3\2\2\2\u0121\u0122\t\6\2\2\u0122\u0123\7")
@@ -180,10 +181,10 @@ def serializedATN():
         buf.write(u"B\"\2\u014f\u0151\3\2\2\2\u0150\u014a\3\2\2\2\u0150\u014d")
         buf.write(u"\3\2\2\2\u0150\u0151\3\2\2\2\u0151\u0158\3\2\2\2\u0152")
         buf.write(u"\u0154\5\n\6\2\u0153\u0152\3\2\2\2\u0153\u0154\3\2\2")
-        buf.write(u"\2\u0154\u0155\3\2\2\2\u0155\u0159\7\65\2\2\u0156\u0159")
+        buf.write(u"\2\u0154\u0155\3\2\2\2\u0155\u0159\7;\2\2\u0156\u0159")
         buf.write(u"\5\62\32\2\u0157\u0159\5\n\6\2\u0158\u0153\3\2\2\2\u0158")
         buf.write(u"\u0156\3\2\2\2\u0158\u0157\3\2\2\2\u0159\u0175\3\2\2")
-        buf.write(u"\2\u015a\u015f\7)\2\2\u015b\u015c\7\r\2\2\u015c\u015d")
+        buf.write(u"\2\u015a\u015f\7/\2\2\u015b\u015c\7\r\2\2\u015c\u015d")
         buf.write(u"\5\b\5\2\u015d\u015e\7\16\2\2\u015e\u0160\3\2\2\2\u015f")
         buf.write(u"\u015b\3\2\2\2\u015f\u0160\3\2\2\2\u0160\u0161\3\2\2")
         buf.write(u"\2\u0161\u0162\7\13\2\2\u0162\u0163\5\b\5\2\u0163\u0164")
@@ -198,31 +199,30 @@ def serializedATN():
         buf.write(u"\3\2\2\2\u0174\u0170\3\2\2\2\u01759\3\2\2\2\u0176\u0177")
         buf.write(u"\5\b\5\2\u0177\u0178\7\3\2\2\u0178\u0179\5:\36\2\u0179")
         buf.write(u"\u017c\3\2\2\2\u017a\u017c\5\b\5\2\u017b\u0176\3\2\2")
-        buf.write(u"\2\u017b\u017a\3\2\2\2\u017c;\3\2\2\2\u017d\u017e\7\62")
+        buf.write(u"\2\u017b\u017a\3\2\2\2\u017c;\3\2\2\2\u017d\u017e\78")
         buf.write(u"\2\2\u017e\u017f\7\13\2\2\u017f\u0180\t\5\2\2\u0180\u0181")
-        buf.write(u"\7\21\2\2\u0181\u0186\5\b\5\2\u0182\u0183\7\63\2\2\u0183")
+        buf.write(u"\7\21\2\2\u0181\u0186\5\b\5\2\u0182\u0183\79\2\2\u0183")
         buf.write(u"\u0184\7\13\2\2\u0184\u0185\t\3\2\2\u0185\u0187\7\f\2")
         buf.write(u"\2\u0186\u0182\3\2\2\2\u0186\u0187\3\2\2\2\u0187\u0188")
         buf.write(u"\3\2\2\2\u0188\u0189\7\f\2\2\u0189=\3\2\2\2\u018a\u0190")
         buf.write(u"\5\b\5\2\u018b\u018c\5\b\5\2\u018c\u018d\7\3\2\2\u018d")
         buf.write(u"\u018e\5> \2\u018e\u0190\3\2\2\2\u018f\u018a\3\2\2\2")
         buf.write(u"\u018f\u018b\3\2\2\2\u0190?\3\2\2\2\u0191\u0192\5\16")
-        buf.write(u"\b\2\u0192A\3\2\2\2\u0193\u0199\7\62\2\2\u0194\u019a")
-        buf.write(u"\5,\27\2\u0195\u0196\7\13\2\2\u0196\u0197\5\b\5\2\u0197")
+        buf.write(u"\b\2\u0192A\3\2\2\2\u0193\u0199\78\2\2\u0194\u019a\5")
+        buf.write(u",\27\2\u0195\u0196\7\13\2\2\u0196\u0197\5\b\5\2\u0197")
         buf.write(u"\u0198\7\f\2\2\u0198\u019a\3\2\2\2\u0199\u0194\3\2\2")
-        buf.write(u"\2\u0199\u0195\3\2\2\2\u019aC\3\2\2\2\u019b\u01a1\7\63")
+        buf.write(u"\2\u0199\u0195\3\2\2\2\u019aC\3\2\2\2\u019b\u01a1\79")
         buf.write(u"\2\2\u019c\u01a2\5,\27\2\u019d\u019e\7\13\2\2\u019e\u019f")
         buf.write(u"\5\b\5\2\u019f\u01a0\7\f\2\2\u01a0\u01a2\3\2\2\2\u01a1")
         buf.write(u"\u019c\3\2\2\2\u01a1\u019d\3\2\2\2\u01a2E\3\2\2\2\u01a3")
-        buf.write(u"\u01a4\7\62\2\2\u01a4\u01a5\7\13\2\2\u01a5\u01a6\5\6")
-        buf.write(u"\4\2\u01a6\u01a7\7\f\2\2\u01a7G\3\2\2\2\u01a8\u01a9\7")
-        buf.write(u"\62\2\2\u01a9\u01aa\7\13\2\2\u01aa\u01ab\5\6\4\2\u01ab")
-        buf.write(u"\u01ac\7\f\2\2\u01acI\3\2\2\2.Tep{\u0083\u0085\u008d")
-        buf.write(u"\u0090\u0096\u009d\u00a2\u00aa\u00b0\u00b8\u00c6\u00c9")
-        buf.write(u"\u00cd\u00da\u00dd\u00e1\u00ea\u00f1\u00ff\u0107\u010c")
-        buf.write(u"\u0116\u012d\u0130\u0133\u0136\u0138\u013f\u0143\u0150")
-        buf.write(u"\u0153\u0158\u015f\u016c\u0174\u017b\u0186\u018f\u0199")
-        buf.write(u"\u01a1")
+        buf.write(u"\u01a4\78\2\2\u01a4\u01a5\7\13\2\2\u01a5\u01a6\5\6\4")
+        buf.write(u"\2\u01a6\u01a7\7\f\2\2\u01a7G\3\2\2\2\u01a8\u01a9\78")
+        buf.write(u"\2\2\u01a9\u01aa\7\13\2\2\u01aa\u01ab\5\6\4\2\u01ab\u01ac")
+        buf.write(u"\7\f\2\2\u01acI\3\2\2\2.Tep{\u0083\u0085\u008d\u0090")
+        buf.write(u"\u0096\u009d\u00a2\u00aa\u00b0\u00b8\u00c6\u00c9\u00cd")
+        buf.write(u"\u00da\u00dd\u00e1\u00ea\u00f1\u00ff\u0107\u010c\u0116")
+        buf.write(u"\u012d\u0130\u0133\u0136\u0138\u013f\u0143\u0150\u0153")
+        buf.write(u"\u0158\u015f\u016c\u0174\u017b\u0186\u018f\u0199\u01a1")
         return buf.getvalue()
 
 
@@ -243,12 +243,13 @@ class LaTeXParser ( Parser ):
                      u"'\\cos'", u"'\\tan'", u"'\\csc'", u"'\\sec'", u"'\\cot'",
                      u"'\\arcsin'", u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'",
                      u"'\\arcsec'", u"'\\arccot'", u"'\\sinh'", u"'\\cosh'",
-                     u"'\\tanh'", u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'",
-                     u"'\\sqrt'", u"'\\times'", u"'\\cdot'", u"'\\div'",
-                     u"'\\frac'", u"'\\binom'", u"'\\dbinom'", u"'\\tbinom'",
-                     u"'\\mathit'", u"'_'", u"'^'", u"':'", u"<INVALID>",
-                     u"<INVALID>", u"<INVALID>", u"'='", u"'<'", u"'\\leq'",
-                     u"'>'", u"'\\geq'", u"'!'" ]
+                     u"'\\tanh'", u"'\\csch'", u"'\\sech'", u"'\\coth'",
+                     u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'", u"'\\arcsch'",
+                     u"'\\arsech'", u"'\\arcoth'", u"'\\sqrt'", u"'\\times'",
+                     u"'\\cdot'", u"'\\div'", u"'\\frac'", u"'\\binom'",
+                     u"'\\dbinom'", u"'\\tbinom'", u"'\\mathit'", u"'_'",
+                     u"'^'", u"':'", u"<INVALID>", u"<INVALID>", u"<INVALID>",
+                     u"'='", u"'<'", u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
 
     symbolicNames = [ u"<INVALID>", u"<INVALID>", u"WS", u"ADD", u"SUB",
                       u"MUL", u"DIV", u"L_PAREN", u"R_PAREN", u"L_BRACE",
@@ -258,12 +259,13 @@ class LaTeXParser ( Parser ):
                       u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT",
                       u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC",
                       u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH",
-                      u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH",
-                      u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV",
-                      u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM",
-                      u"CMD_MATHIT", u"UNDERSCORE", u"CARET", u"COLON",
-                      u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL", u"LT",
-                      u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                      u"FUNC_TANH", u"FUNC_CSCH", u"FUNC_SECH", u"FUNC_COTH",
+                      u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH", u"FUNC_ARCSCH",
+                      u"FUNC_ARSECH", u"FUNC_ARCOTH", u"FUNC_SQRT", u"CMD_TIMES",
+                      u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM",
+                      u"CMD_DBINOM", u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE",
+                      u"CARET", u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER",
+                      u"EQUAL", u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
 
     RULE_math = 0
     RULE_relation = 1
@@ -347,37 +349,44 @@ class LaTeXParser ( Parser ):
     FUNC_SINH=33
     FUNC_COSH=34
     FUNC_TANH=35
-    FUNC_ARSINH=36
-    FUNC_ARCOSH=37
-    FUNC_ARTANH=38
-    FUNC_SQRT=39
-    CMD_TIMES=40
-    CMD_CDOT=41
-    CMD_DIV=42
-    CMD_FRAC=43
-    CMD_BINOM=44
-    CMD_DBINOM=45
-    CMD_TBINOM=46
-    CMD_MATHIT=47
-    UNDERSCORE=48
-    CARET=49
-    COLON=50
-    DIFFERENTIAL=51
-    LETTER=52
-    NUMBER=53
-    EQUAL=54
-    LT=55
-    LTE=56
-    GT=57
-    GTE=58
-    BANG=59
-    SYMBOL=60
+    FUNC_CSCH=36
+    FUNC_SECH=37
+    FUNC_COTH=38
+    FUNC_ARSINH=39
+    FUNC_ARCOSH=40
+    FUNC_ARTANH=41
+    FUNC_ARCSCH=42
+    FUNC_ARSECH=43
+    FUNC_ARCOTH=44
+    FUNC_SQRT=45
+    CMD_TIMES=46
+    CMD_CDOT=47
+    CMD_DIV=48
+    CMD_FRAC=49
+    CMD_BINOM=50
+    CMD_DBINOM=51
+    CMD_TBINOM=52
+    CMD_MATHIT=53
+    UNDERSCORE=54
+    CARET=55
+    COLON=56
+    DIFFERENTIAL=57
+    LETTER=58
+    NUMBER=59
+    EQUAL=60
+    LT=61
+    LTE=62
+    GT=63
+    GTE=64
+    BANG=65
+    SYMBOL=66
 
     def __init__(self, input, output=sys.stdout):
         super(LaTeXParser, self).__init__(input, output=output)
-        self.checkVersion("4.7.1")
+        self.checkVersion("4.7.2")
         self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
         self._predicates = None
+
 
 
 
@@ -412,6 +421,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class RelationContext(ParserRuleContext):
 
@@ -479,7 +489,7 @@ class LaTeXParser ( Parser ):
                         raise FailedPredicateException(self, "self.precpred(self._ctx, 2)")
                     self.state = 78
                     _la = self._input.LA(1)
-                    if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.EQUAL) | (1 << LaTeXParser.LT) | (1 << LaTeXParser.LTE) | (1 << LaTeXParser.GT) | (1 << LaTeXParser.GTE))) != 0)):
+                    if not(((((_la - 60)) & ~0x3f) == 0 and ((1 << (_la - 60)) & ((1 << (LaTeXParser.EQUAL - 60)) | (1 << (LaTeXParser.LT - 60)) | (1 << (LaTeXParser.LTE - 60)) | (1 << (LaTeXParser.GT - 60)) | (1 << (LaTeXParser.GTE - 60)))) != 0)):
                         self._errHandler.recoverInline(self)
                     else:
                         self._errHandler.reportMatch(self)
@@ -497,6 +507,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.unrollRecursionContexts(_parentctx)
         return localctx
+
 
     class EqualityContext(ParserRuleContext):
 
@@ -540,6 +551,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class ExprContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -571,6 +583,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class AdditiveContext(ParserRuleContext):
 
@@ -647,6 +660,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.unrollRecursionContexts(_parentctx)
         return localctx
+
 
     class MpContext(ParserRuleContext):
 
@@ -736,6 +750,7 @@ class LaTeXParser ( Parser ):
             self.unrollRecursionContexts(_parentctx)
         return localctx
 
+
     class Mp_nofuncContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -824,6 +839,7 @@ class LaTeXParser ( Parser ):
             self.unrollRecursionContexts(_parentctx)
         return localctx
 
+
     class UnaryContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -874,7 +890,7 @@ class LaTeXParser ( Parser ):
                 self.state = 125
                 self.unary()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_CSCH, LaTeXParser.FUNC_SECH, LaTeXParser.FUNC_COTH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_ARCSCH, LaTeXParser.FUNC_ARSECH, LaTeXParser.FUNC_ARCOTH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 127
                 self._errHandler.sync(self)
@@ -901,6 +917,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class Unary_nofuncContext(ParserRuleContext):
 
@@ -956,7 +973,7 @@ class LaTeXParser ( Parser ):
                 self.state = 134
                 self.unary_nofunc()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_CSCH, LaTeXParser.FUNC_SECH, LaTeXParser.FUNC_COTH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_ARCSCH, LaTeXParser.FUNC_ARSECH, LaTeXParser.FUNC_ARCOTH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 135
                 self.postfix()
@@ -982,6 +999,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class PostfixContext(ParserRuleContext):
 
@@ -1033,6 +1051,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Postfix_nofuncContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1083,6 +1102,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Postfix_opContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1130,6 +1150,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class Eval_atContext(ParserRuleContext):
 
@@ -1190,6 +1211,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class Eval_at_subContext(ParserRuleContext):
 
@@ -1254,6 +1276,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Eval_at_supContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1316,6 +1339,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class ExpContext(ParserRuleContext):
 
@@ -1423,6 +1447,7 @@ class LaTeXParser ( Parser ):
             self.unrollRecursionContexts(_parentctx)
         return localctx
 
+
     class Exp_nofuncContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1529,6 +1554,7 @@ class LaTeXParser ( Parser ):
             self.unrollRecursionContexts(_parentctx)
         return localctx
 
+
     class CompContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1618,6 +1644,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Comp_nofuncContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1693,6 +1720,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class GroupContext(ParserRuleContext):
 
@@ -1774,6 +1802,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Abs_groupContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1815,6 +1844,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class AtomContext(ParserRuleContext):
 
@@ -1901,6 +1931,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class MathitContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1948,6 +1979,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Mathit_textContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -1990,6 +2022,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class FracContext(ParserRuleContext):
 
@@ -2054,6 +2087,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class BinomContext(ParserRuleContext):
 
@@ -2131,6 +2165,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Func_normalContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2188,6 +2223,15 @@ class LaTeXParser ( Parser ):
         def FUNC_TANH(self):
             return self.getToken(LaTeXParser.FUNC_TANH, 0)
 
+        def FUNC_CSCH(self):
+            return self.getToken(LaTeXParser.FUNC_CSCH, 0)
+
+        def FUNC_SECH(self):
+            return self.getToken(LaTeXParser.FUNC_SECH, 0)
+
+        def FUNC_COTH(self):
+            return self.getToken(LaTeXParser.FUNC_COTH, 0)
+
         def FUNC_ARSINH(self):
             return self.getToken(LaTeXParser.FUNC_ARSINH, 0)
 
@@ -2196,6 +2240,15 @@ class LaTeXParser ( Parser ):
 
         def FUNC_ARTANH(self):
             return self.getToken(LaTeXParser.FUNC_ARTANH, 0)
+
+        def FUNC_ARCSCH(self):
+            return self.getToken(LaTeXParser.FUNC_ARCSCH, 0)
+
+        def FUNC_ARSECH(self):
+            return self.getToken(LaTeXParser.FUNC_ARSECH, 0)
+
+        def FUNC_ARCOTH(self):
+            return self.getToken(LaTeXParser.FUNC_ARCOTH, 0)
 
         def getRuleIndex(self):
             return LaTeXParser.RULE_func_normal
@@ -2212,7 +2265,7 @@ class LaTeXParser ( Parser ):
             self.enterOuterAlt(localctx, 1)
             self.state = 295
             _la = self._input.LA(1)
-            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH))) != 0)):
+            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_CSCH) | (1 << LaTeXParser.FUNC_SECH) | (1 << LaTeXParser.FUNC_COTH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH) | (1 << LaTeXParser.FUNC_ARCSCH) | (1 << LaTeXParser.FUNC_ARSECH) | (1 << LaTeXParser.FUNC_ARCOTH))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
@@ -2224,6 +2277,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class FuncContext(ParserRuleContext):
 
@@ -2341,7 +2395,7 @@ class LaTeXParser ( Parser ):
             self.state = 370
             self._errHandler.sync(self)
             token = self._input.LA(1)
-            if token in [LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH]:
+            if token in [LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_CSCH, LaTeXParser.FUNC_SECH, LaTeXParser.FUNC_COTH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_ARCSCH, LaTeXParser.FUNC_ARSECH, LaTeXParser.FUNC_ARCOTH]:
                 self.enterOuterAlt(localctx, 1)
                 self.state = 297
                 self.func_normal()
@@ -2449,7 +2503,7 @@ class LaTeXParser ( Parser ):
                     self.state = 332
                     self.subexpr()
                     pass
-                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_CSCH, LaTeXParser.FUNC_SECH, LaTeXParser.FUNC_COTH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_ARCSCH, LaTeXParser.FUNC_ARSECH, LaTeXParser.FUNC_ARCOTH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                     pass
                 else:
                     pass
@@ -2554,6 +2608,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class ArgsContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2606,6 +2661,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class Limit_subContext(ParserRuleContext):
 
@@ -2707,6 +2763,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Func_argContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2760,6 +2817,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class Func_arg_noparensContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2791,6 +2849,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class SubexprContext(ParserRuleContext):
 
@@ -2855,6 +2914,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class SupexprContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2918,6 +2978,7 @@ class LaTeXParser ( Parser ):
             self.exitRule()
         return localctx
 
+
     class SubeqContext(ParserRuleContext):
 
         def __init__(self, parser, parent=None, invokingState=-1):
@@ -2964,6 +3025,7 @@ class LaTeXParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
+
 
     class SupeqContext(ParserRuleContext):
 

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -389,7 +389,7 @@ def convert_func(func):
         ]:
             name = "a" + name[3:]
             expr = getattr(sympy.functions, name)(arg, evaluate=False)
-        if name in ["arsinh", "arcosh", "artanh"]:
+        if name in ["arsinh", "arcosh", "artanh", "arcsch", "arsech", "arcoth"]:
             name = "a" + name[2:]
             expr = getattr(sympy.functions, name)(arg, evaluate=False)
 
@@ -412,7 +412,7 @@ def convert_func(func):
 
         if name in [
                 "sin", "cos", "tan", "csc", "sec", "cot", "sinh", "cosh",
-                "tanh"
+                "tanh", "csch", "sech", "coth"
         ]:
             if func_pow == -1:
                 name = "a" + name

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -3,7 +3,7 @@ from sympy.external import import_module
 
 from sympy import (
     Symbol, Mul, Add, Eq, Abs, sin, asin, cos, Pow,
-    csc, sec, Limit, oo, Derivative, Integral, factorial,
+    csc, csch, sec, Limit, oo, Derivative, Integral, factorial,
     sqrt, root, StrictLessThan, LessThan, StrictGreaterThan,
     GreaterThan, Sum, Product, E, log, tan, Function, binomial
 )
@@ -79,6 +79,7 @@ GOOD_PAIRS = [
     ("\\sin a \\cos b", _Mul(sin(a), cos(b))),
     ("\\sin \\cos \\theta", sin(cos(theta))),
     ("\\sin(\\cos \\theta)", sin(cos(theta))),
+    ("\\csch^2(\\theta)", csch(theta)**2),
     ("\\frac{a}{b}", a / b),
     ("\\frac{a + b}{c}", _Mul(a + b, _Pow(c, -1))),
     ("\\frac{7}{3}", _Mul(7, _Pow(3, -1))),


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Recognize CSCH, SECH, COTH, ARCSCH, ARSECH, ARCOTH
as function when using `parse_latex`

#### Other comments
⚠️ Files under `_antlr` are AUTOGENERATED ⚠️ 

#### Release Notes
<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->