### PR TITLE
Support log expand of even powers of real numbers

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -789,7 +789,7 @@ class log(Function):
             expr = []
             nonpos = []
             for x in arg.args:
-                if force or not x.is_negative or x.is_polar:
+                if force or (x.is_real and not x.is_negative) or x.is_polar:
                     a = self.func(x)
                     if isinstance(a, log):
                         expr.append(self.func(x)._eval_expand_log(**hints))
@@ -809,6 +809,9 @@ class log(Function):
             if e % 2 == 0 and b.is_real:
                 # even power and real base obeys the power rule: log(b^e) = e log(Abs(b))
                 return e * self.func(Abs(b))
+            elif e % 3 == 0 and b.is_real:
+                # odd power and real base obeys the power rule: log(b^e) = e log(b)
+                return e * self.func(b)
             elif force or (e.is_extended_real and (b.is_positive or ((e+1)
                 .is_positive and (e-1).is_nonpositive))) or b.is_polar:
                 a = self.func(b)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -762,6 +762,7 @@ class log(Function):
     def _eval_expand_log(self, deep=True, **hints):
         from sympy import unpolarify, expand_log, factorint
         from sympy.concrete import Sum, Product
+        from sympy.functions.elementary.complexes import Abs
         force = hints.get('force', False)
         factor = hints.get('factor', False)
         if (len(self.args) == 2):
@@ -788,7 +789,7 @@ class log(Function):
             expr = []
             nonpos = []
             for x in arg.args:
-                if force or x.is_positive or x.is_polar:
+                if force or not x.is_negative or x.is_polar:
                     a = self.func(x)
                     if isinstance(a, log):
                         expr.append(self.func(x)._eval_expand_log(**hints))
@@ -802,10 +803,14 @@ class log(Function):
                     nonpos.append(x)
             return Add(*expr) + log(Mul(*nonpos))
         elif arg.is_Pow or isinstance(arg, exp):
-            if force or (arg.exp.is_extended_real and (arg.base.is_positive or ((arg.exp+1)
-                .is_positive and (arg.exp-1).is_nonpositive))) or arg.base.is_polar:
-                b = arg.base
-                e = arg.exp
+            # expanding log(b^e)
+            b = arg.base
+            e = arg.exp
+            if e % 2 == 0 and b.is_real:
+                # even power and real base obeys the power rule: log(b^e) = e log(Abs(b))
+                return e * self.func(Abs(b))
+            elif force or (e.is_extended_real and (b.is_positive or ((e+1)
+                .is_positive and (e-1).is_nonpositive))) or b.is_polar:
                 a = self.func(b)
                 if isinstance(a, log):
                     return unpolarify(e) * a._eval_expand_log(**hints)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -4,6 +4,7 @@ from sympy import (
     adjoint, conjugate, transpose, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, simplify,
     AccumBounds, MatrixSymbol, Pow, gcd, Sum, Product)
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import match_real_imag
 from sympy.abc import x, y, z
 from sympy.core.expr import unchanged
@@ -445,15 +446,16 @@ def test_log_expand():
     assert e.expand() == log(5)/log(3) * log(w)
     x, y, z = symbols('x,y,z', positive=True)
     assert log(x*(y + z)).expand(mul=False) == log(x) + log(y + z)
-    assert log(log(x**2)*log(y*z)).expand() in [log(2*log(x)*log(y) +
-        2*log(x)*log(z)), log(log(x)*log(z) + log(y)*log(x)) + log(2),
-        log((log(y) + log(z))*log(x)) + log(2)]
+    assert log(log(x**2)*log(y*z)).expand() == log(log(y) + log(z)) + log(log(x)) + log(2)
     assert log(x**log(x**2)).expand(deep=False) == log(x)*log(x**2)
     assert log(x**log(x**2)).expand() == 2*log(x)**2
     x, y = symbols('x,y')
     assert log(x*y).expand(force=True) == log(x) + log(y)
     assert log(x**y).expand(force=True) == y*log(x)
     assert log(exp(x)).expand(force=True) == x
+    x, y, z = symbols('x,y,z', real=True)
+
+    assert log(y**2 * x**4 * z).expand() == 2 * log(Abs(y)) + 4 * log(Abs(x)) + log(z)
 
     # there's generally no need to expand out logs since this requires
     # factoring and if simplification is sought, it's cheaper to put

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -450,12 +450,14 @@ def test_log_expand():
     assert log(x**log(x**2)).expand(deep=False) == log(x)*log(x**2)
     assert log(x**log(x**2)).expand() == 2*log(x)**2
     x, y = symbols('x,y')
+    # if we don't know whether variables are real or complex, we can't expand
+    assert log(x**2 * y**3).expand() == log(x**2 * y**3)
     assert log(x*y).expand(force=True) == log(x) + log(y)
     assert log(x**y).expand(force=True) == y*log(x)
     assert log(exp(x)).expand(force=True) == x
-    x, y, z = symbols('x,y,z', real=True)
 
-    assert log(y**2 * x**4 * z).expand() == 2 * log(Abs(y)) + 4 * log(Abs(x)) + log(z)
+    x, y, z = symbols('x,y,z', real=True)
+    assert log(y**2 * x**3 * z).expand() == 2 * log(Abs(y)) + 3 * log(x) + log(z)
 
     # there's generally no need to expand out logs since this requires
     # factoring and if simplification is sought, it's cheaper to put


### PR DESCRIPTION
For a real number x and even int n, the identity

log(x**n) == n * log(Abs(x))

now holds.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->